### PR TITLE
Add protobuf so copy for linux platform

### DIFF
--- a/iroha_bindings.sh
+++ b/iroha_bindings.sh
@@ -18,3 +18,9 @@ sh ${bindings_dir}/build_library.sh
 
 # move generate files to repository
 cp -R ${bindings_dir}/dist/* ${build}
+
+# move protoc library to bindings
+unamestr=`uname`
+if [[ "$unamestr" == 'Linux' ]]; then
+    cp vendor/iroha/external/src/google_protobuf-build/libprotobuf.so dist/
+fi


### PR DESCRIPTION
Add missed protobuf library for Linux platform.
Also, we have to merge https://github.com/hyperledger/iroha/pull/1289 to our subtree.