### PR TITLE
Add library for JSON

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,9 @@ dependencies {
     compile "io.ktor:ktor-server-core:$ktor_version"
     compile "io.ktor:ktor-server-netty:$ktor_version"
 
+    // JSON converter
+    implementation 'com.squareup.moshi:moshi-kotlin:1.5.0'
+
     // ------------------| Test dependencies |------------------
 
     // unit tests

--- a/src/test/kotlin/vendor/moshi.kt
+++ b/src/test/kotlin/vendor/moshi.kt
@@ -1,0 +1,35 @@
+package vendor
+
+import com.squareup.moshi.Moshi
+import mu.KLogging
+import org.junit.Assert
+import org.junit.Test
+
+
+data class Engine(val temperature: Int)
+
+data class Passenger(val name: String)
+
+data class Car(val engine: Engine, val passengers: List<Passenger>)
+
+class MoshiUsage {
+    @Test
+    fun usageTest() {
+        val moshi = Moshi.Builder().build()
+        val jsonAdapter = moshi.adapter(Car::class.java)
+
+        val car = Car(Engine(452), listOf(Passenger("Joker"), Passenger("Hartman")))
+
+        val jsonRepr = jsonAdapter.toJson(car)
+        logger.info { "JSON representation:$jsonRepr" }
+
+        val jsonCar = jsonAdapter.fromJson(jsonRepr)
+
+        Assert.assertEquals(car, jsonCar)
+    }
+
+    /**
+     * Logger
+     */
+    companion object : KLogging()
+}


### PR DESCRIPTION
Add Moshi library for working with JSON format.
JSON is required for performing refund requests.