### PR TITLE
Rename map to bind

### DIFF
--- a/src/main/kotlin/endpoint/RefundServerEndpoint.kt
+++ b/src/main/kotlin/endpoint/RefundServerEndpoint.kt
@@ -12,8 +12,8 @@ import io.ktor.routing.routing
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
 import mu.KLogging
+import util.functional.bind
 import util.functional.endValue
-import util.functional.map
 import util.functional.truePredicate
 
 /**
@@ -47,10 +47,10 @@ class RefundServerEndpoint(
      */
     fun onCallEthRefund(rawRequest: String?): String {
         return rawRequest
-            .map(ethRefundAdapter::fromJson)
+            .bind(ethRefundAdapter::fromJson)
             .truePredicate(ethStrategy::validate)
-            .map(ethStrategy::performRefund)
-            .map(ethNotaryAdapter::toJson)
+            .bind(ethStrategy::performRefund)
+            .bind(ethNotaryAdapter::toJson)
             .endValue({
                 it
             }, {

--- a/src/main/kotlin/util/functional/bind.kt
+++ b/src/main/kotlin/util/functional/bind.kt
@@ -4,7 +4,7 @@ package util.functional
  * Functional application of lambda to nullable type
  * @return application of lambda to value or null
  */
-fun <T, R> T?.map(map: (value: T) -> R?): R? {
+fun <T, R> T?.bind(map: (value: T) -> R?): R? {
     return if (this != null) {
         map(this)
     } else null
@@ -34,7 +34,7 @@ fun <T, R> T?.endValue(value: (value: T) -> R, empty: () -> R): R {
  * Check predicate on value and return this if true
  */
 fun <T> T?.truePredicate(value: (value: T) -> Boolean): T? {
-    return this.map {
+    return this.bind {
         if (value(it)) this else null
     }
 }

--- a/src/test/util/functional/BindTest.kt
+++ b/src/test/util/functional/BindTest.kt
@@ -18,25 +18,25 @@ class BindTest {
 
     /**
      * @given value as input
-     * @when  map on input
+     * @when  bind on input
      * @then  mapped value is not a null
      */
     @Test
     fun mapUsage() {
-        val bound = value.map { "1" }
-            .map { it + it }
+        val bound = value.bind { "1" }
+            .bind { it + it }
 
         assertEquals("11", bound)
     }
 
     /**
      * @given null as input
-     * @when  map on input
+     * @when  bind on input
      * @then  mapped value is a null
      */
     @Test
     fun mapNullUsage() {
-        val bound = nullValue.map { 1 }
+        val bound = nullValue.bind { 1 }
 
         assertEquals(null, bound)
     }


### PR DESCRIPTION
Resolving of the extension function is broken in Kotlin.
Our `map` and `map` for collections isn't resolved properly.

The solution is just to rename our `map` to `bind`.