### PR TITLE
fix pubkey size sent to Iroha

### DIFF
--- a/src/main/kotlin/sidechain/iroha/consumer/IrohaConverterImpl.kt
+++ b/src/main/kotlin/sidechain/iroha/consumer/IrohaConverterImpl.kt
@@ -31,7 +31,7 @@ class IrohaConverterImpl {
                         txBuilder = txBuilder.createAccount(
                             cmd.accountName,
                             cmd.domainId,
-                            PublicKey(cmd.mainPubkey)
+                            PublicKey(PublicKey.fromHexString(cmd.mainPubkey))
                         )
                     is IrohaCommand.CommandAddAssetQuantity ->
                         txBuilder = txBuilder.addAssetQuantity(
@@ -42,7 +42,7 @@ class IrohaConverterImpl {
                     is IrohaCommand.CommandAddSignatory ->
                         txBuilder = txBuilder.addSignatory(
                             cmd.accountId,
-                            PublicKey(cmd.publicKey)
+                            PublicKey(PublicKey.fromHexString(cmd.publicKey))
                         )
                     is IrohaCommand.CommandCreateAsset ->
                         txBuilder = txBuilder.createAsset(

--- a/src/test/kotlin/registration/RegistrationTest.kt
+++ b/src/test/kotlin/registration/RegistrationTest.kt
@@ -19,7 +19,7 @@ open class RegistrationTest {
     private val correctName = "green"
 
     /** Correct user public key */
-    private val correctPubkey = "12345678901234567890123456789012"
+    private val correctPubkey = "0f0ce16d2afbb8eca23c7d8c2724f0c257a800ee2bbd54688cec6b898e3f7e33"
 
     /** Registration strategy that always returns true */
     private val strategy: RegistrationStrategy = mock {


### PR DESCRIPTION
Previously it was assumed to send byte representation, now fixed to string representation.