### PR TITLE
Add bunch of contracts tests

### DIFF
--- a/src/test/integration/ContractsTest.kt
+++ b/src/test/integration/ContractsTest.kt
@@ -5,11 +5,13 @@ import config.loadConfigs
 import contract.BasicCoin
 import contract.Master
 import contract.Relay
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.web3j.crypto.Hash
 import org.web3j.protocol.core.DefaultBlockParameterName
+import org.web3j.protocol.exceptions.TransactionException
 import org.web3j.utils.Numeric.hexStringToByteArray
 import sidechain.eth.util.DeployHelper
 import sidechain.eth.util.hashToWithdraw
@@ -20,26 +22,29 @@ import java.math.BigInteger
  * Class for Ethereum sidechain infrastructure deployment and communication.
  */
 class ContractsTest {
-    val testConfig = loadConfigs("test", TestConfig::class.java)
-    val passwordConfig = loadConfigs("test", EthereumPasswords::class.java, "/ethereum_password.properties")
+    private val testConfig = loadConfigs("test", TestConfig::class.java)
+    private val passwordConfig = loadConfigs("test", EthereumPasswords::class.java, "/ethereum_password.properties")
 
-    val deployHelper = DeployHelper(testConfig.ethereum, passwordConfig)
+    private val deployHelper = DeployHelper(testConfig.ethereum, passwordConfig)
 
     private lateinit var token: BasicCoin
     private lateinit var master: Master
     private lateinit var relay: Relay
 
+    private var addPeerCalls: Int = 0
+
     // some ropsten account
     private val accGreen = "0x93668c6b9b8b9b9ea2393ab689e413cdd1e3440f"
 
     private fun sendAddPeer(address: String) {
+        ++addPeerCalls
         val addPeer = master.addPeer(address).send()
         // addPeer call produces 2 events
         // first event is amount of peers after new peer was added
         // second one is address of added peer
         // events should be aligned to 64 hex digits and prefixed with 0x
         assertEquals(2, addPeer.logs.size)
-        assertEquals("0x" + String.format("%064x", 1), addPeer.logs[0].data)
+        assertEquals("0x" + String.format("%064x", addPeerCalls), addPeer.logs[0].data)
         assertEquals(
             "0x" + "0".repeat(24) +
                     address.slice(2 until address.length),
@@ -107,6 +112,7 @@ class ContractsTest {
         master = deployHelper.deployMasterSmartContract()
         Thread.sleep(120_000)
         relay = deployHelper.deployRelaySmartContract(master.contractAddress, listOf(token.contractAddress))
+        addPeerCalls = 0
     }
 
     /**
@@ -142,6 +148,54 @@ class ContractsTest {
         transferTokensToMaster(BigInteger.valueOf(5))
         withdraw(BigInteger.valueOf(1))
         assertEquals(BigInteger.valueOf(4), token.balanceOf(master.contractAddress).send())
+    }
+
+    /**
+     * @given deployed master and token contracts
+     * @when two peers added to master, 5 tokens transferred to master,
+     * request to withdraw 1 token is sent to master
+     * @then call to withdraw fails
+     */
+    @Test
+    fun singleNotEnoughSignaturesTokenTest() {
+        sendAddPeer(deployHelper.credentials.address)
+        sendAddPeer(accGreen)
+        transferTokensToMaster(BigInteger.valueOf(5))
+        Assertions.assertThrows(TransactionException::class.java) { withdraw(BigInteger.valueOf(1)) }
+    }
+
+    /**
+     * @given deployed master and token contracts
+     * @when one peer added to master, 5000 WEI transferred to master,
+     * request to withdraw 10000 WEI is sent to master
+     * @then call to withdraw fails
+     */
+    @Test
+    fun notEnoughEtherTest() {
+        sendAddPeer(deployHelper.credentials.address)
+        deployHelper.sendEthereum(BigInteger.valueOf(5000), master.contractAddress)
+        // have to wait some time until balance will be updated
+        Thread.sleep(120_000)
+        Assertions.assertThrows(TransactionException::class.java) {
+            withdraw(
+                BigInteger.valueOf(10000),
+                tokenAddress = "0x0000000000000000000000000000000000000000",
+                to = accGreen
+            )
+        }
+    }
+
+    /**
+     * @given deployed master and token contracts
+     * @when one peer added to master, 5 tokens transferred to master,
+     * request to withdraw 10 tokens is sent to master
+     * @then call to withdraw fails
+     */
+    @Test
+    fun notEnoughTokensTest() {
+        sendAddPeer(deployHelper.credentials.address)
+        transferTokensToMaster(BigInteger.valueOf(5))
+        Assertions.assertThrows(TransactionException::class.java) { withdraw(BigInteger.valueOf(10)) }
     }
 
     /**
@@ -203,6 +257,151 @@ class ContractsTest {
 
     /**
      * @given deployed master and token contracts
+     * @when 5 tokens transferred to master,
+     * request to withdraw 1 token is sent to master
+     * @then withdraw attempt fails
+     */
+    @Test
+    fun noPeersWithdraw() {
+        transferTokensToMaster(BigInteger.valueOf(5))
+        Assertions.assertThrows(TransactionException::class.java) { withdraw(BigInteger.valueOf(1)) }
+    }
+
+    /**
+     * @given deployed master and token contracts
+     * @when one peer added to master, 5 tokens transferred to master,
+     * request to withdraw 1 token is sent to master with r-array larger than v and s
+     * @then withdraw attempt fails
+     */
+    @Test
+    fun differentVRS() {
+        sendAddPeer(deployHelper.credentials.address)
+        transferTokensToMaster(BigInteger.valueOf(5))
+
+        val amount = BigInteger.valueOf(1)
+        val irohaHash = Hash.sha3(String.format("%064x", BigInteger.valueOf(12345)))
+        val finalHash = hashToWithdraw(token.contractAddress, amount.toString(), accGreen, irohaHash)
+
+        val signature = signUserData(testConfig.ethereum, passwordConfig, finalHash)
+        val r = hexStringToByteArray(signature.substring(2, 66))
+        val s = hexStringToByteArray(signature.substring(66, 130))
+        val v = signature.substring(130, 132).toBigInteger(16)
+
+        val vv = ArrayList<BigInteger>()
+        vv.add(v)
+        val rr = ArrayList<ByteArray>()
+        rr.add(r)
+        val ss = ArrayList<ByteArray>()
+        ss.add(s)
+        rr.add(s)
+
+        val byteHash = hexStringToByteArray(irohaHash.slice(2 until irohaHash.length))
+
+        Assertions.assertThrows(TransactionException::class.java) {
+            master.withdraw(
+                token.contractAddress,
+                amount,
+                accGreen,
+                byteHash,
+                vv,
+                rr,
+                ss
+            ).send()
+        }
+    }
+
+    /**
+     * @given deployed master and token contracts
+     * @when one peer added to master, 5 tokens transferred to master,
+     * request to withdraw 1 token is sent to master with valid signature repeated twice
+     * @then call to withdraw fails
+     * //TODO: withdraw should pass successfully until amount of duplicated and other invalid signatures <= f
+     */
+    @Test
+    fun sameSignatures() {
+        sendAddPeer(deployHelper.credentials.address)
+        transferTokensToMaster(BigInteger.valueOf(5))
+
+        val amount = BigInteger.valueOf(1)
+        val irohaHash = Hash.sha3(String.format("%064x", BigInteger.valueOf(12345)))
+        val finalHash = hashToWithdraw(token.contractAddress, amount.toString(), accGreen, irohaHash)
+
+        val signature = signUserData(testConfig.ethereum, passwordConfig, finalHash)
+        val r = hexStringToByteArray(signature.substring(2, 66))
+        val s = hexStringToByteArray(signature.substring(66, 130))
+        val v = signature.substring(130, 132).toBigInteger(16)
+
+        val vv = ArrayList<BigInteger>()
+        vv.add(v)
+        vv.add(v)
+        val rr = ArrayList<ByteArray>()
+        rr.add(r)
+        rr.add(r)
+        val ss = ArrayList<ByteArray>()
+        ss.add(s)
+        ss.add(s)
+
+        val byteHash = hexStringToByteArray(irohaHash.slice(2 until irohaHash.length))
+
+        Assertions.assertThrows(TransactionException::class.java) {
+            master.withdraw(
+                token.contractAddress,
+                amount,
+                accGreen,
+                byteHash,
+                vv,
+                rr,
+                ss
+            ).send()
+        }
+    }
+
+    /**
+     * @given deployed master and token contracts
+     * @when one peer added to master, 5 tokens transferred to master,
+     * request to withdraw 1 token is sent to master with invalid signature
+     * @then call to withdraw fails
+     */
+    @Test
+    fun invalidSignature() {
+        sendAddPeer(deployHelper.credentials.address)
+        transferTokensToMaster(BigInteger.valueOf(5))
+
+        val amount = BigInteger.valueOf(1)
+        val irohaHash = Hash.sha3(String.format("%064x", BigInteger.valueOf(12345)))
+        val finalHash = hashToWithdraw(token.contractAddress, amount.toString(), accGreen, irohaHash)
+
+        val signature = signUserData(testConfig.ethereum, passwordConfig, finalHash)
+        val r = hexStringToByteArray(signature.substring(2, 66))
+        val s = hexStringToByteArray(signature.substring(66, 130))
+        // let's corrupt first byte of s
+        s[0] = s[0].inc()
+        val v = signature.substring(130, 132).toBigInteger(16)
+
+        val vv = ArrayList<BigInteger>()
+        vv.add(v)
+        val rr = ArrayList<ByteArray>()
+        rr.add(r)
+        val ss = ArrayList<ByteArray>()
+        ss.add(s)
+
+        val byteHash = hexStringToByteArray(irohaHash.slice(2 until irohaHash.length))
+
+        Assertions.assertThrows(TransactionException::class.java) {
+            master.withdraw(
+                token.contractAddress,
+                amount,
+                accGreen,
+                byteHash,
+                vv,
+                rr,
+                ss
+            ).send()
+        }
+    }
+
+    /**
+     * @given deployed master and token contracts
      * @when one peer added to master, 5 tokens transferred to master,
      * request to withdraw 1 token is sent to master twice
      * @then second call to withdraw failed
@@ -215,5 +414,27 @@ class ContractsTest {
         assertEquals(BigInteger.valueOf(4), token.balanceOf(master.contractAddress).send())
         withdraw(BigInteger.valueOf(1))
         assertEquals(BigInteger.valueOf(4), token.balanceOf(master.contractAddress).send())
+    }
+
+    /**
+     * @given deployed master contract
+     * @when AddPeer called twice with different addresses
+     * @then both calls succeeded
+     */
+    @Test
+    fun addPeerTest() {
+        sendAddPeer(deployHelper.credentials.address)
+        sendAddPeer(accGreen)
+    }
+
+    /**
+     * @given deployed master contract
+     * @when AddPeer called twice with same addresses
+     * @then second call fails
+     */
+    @Test
+    fun addSamePeer() {
+        sendAddPeer(accGreen)
+        Assertions.assertThrows(TransactionException::class.java) { master.addPeer(accGreen).send() }
     }
 }


### PR DESCRIPTION
Cases covered:

- Not enough tokens to withdraw
- Not enough ether to withdraw
- Not enough signatures provided
- No peers were added
- V, r and s arrays are not the same size
- Two exactly the same signatures provided (this one should be handled by contract differently)
- Signature is invalid
- Two different peers were added
- One peer was added twice