### PR TITLE
fix getWallets in notary

### DIFF
--- a/src/main/kotlin/notary/NotaryInitialization.kt
+++ b/src/main/kotlin/notary/NotaryInitialization.kt
@@ -65,21 +65,16 @@ class NotaryInitialization(
 
         val web3 = Web3j.build(HttpService(notaryConfig.ethereum.url))
         /** List of all observable wallets */
-        return ethWalletsProvider.getWallets()
-            .fanout {
-                /** List of all observable ERC20 tokens */
-                ethTokensProvider.getTokens()
-            }.flatMap { (wallets, tokens) ->
-                val ethHandler = EthChainHandler(web3, wallets, tokens)
-                EthChainListener(
-                    web3,
-                    BigInteger.valueOf(notaryConfig.ethereum.confirmationPeriod)
-                ).getBlockObservable()
-                    .map { observable ->
-                        observable.flatMapIterable { ethHandler.parseBlock(it) }
-                    }
+        val ethHandler = EthChainHandler(web3, ethWalletsProvider, ethTokensProvider)
+        return EthChainListener(
+            web3,
+            BigInteger.valueOf(notaryConfig.ethereum.confirmationPeriod)
+        ).getBlockObservable()
+            .map { observable ->
+                observable.flatMapIterable { ethHandler.parseBlock(it) }
             }
     }
+
 
     /**
      * Init Iroha chain listener

--- a/src/main/kotlin/sidechain/eth/EthChainHandler.kt
+++ b/src/main/kotlin/sidechain/eth/EthChainHandler.kt
@@ -1,6 +1,9 @@
 package sidechain.eth
 
+import com.github.kittinunf.result.fanout
 import mu.KLogging
+import notary.EthTokensProvider
+import notary.EthWalletsProvider
 import org.web3j.protocol.Web3j
 import org.web3j.protocol.core.methods.response.EthBlock
 import org.web3j.protocol.core.methods.response.Transaction
@@ -12,10 +15,14 @@ import java.math.BigInteger
  * Implementation of [ChainHandler] for Ethereum side chain.
  * Extract interesting transactions from Ethereum block.
  * @param web3 - notary.endpoint of Ethereum client
- * @param wallets - map of observable wallets (wallet address -> user name)
- * @param tokens - map of observable tokens (token address -> token name)
+ * @param ethWalletsProvider - provider of observable wallets
+ * @param ethTokensProvider - provider of observable tokens
  */
-class EthChainHandler(val web3: Web3j, val wallets: Map<String, String>, val tokens: Map<String, String>) :
+class EthChainHandler(
+    val web3: Web3j,
+    val ethWalletsProvider: EthWalletsProvider,
+    val ethTokensProvider: EthTokensProvider
+) :
     ChainHandler<EthBlock> {
 
     /**
@@ -23,9 +30,14 @@ class EthChainHandler(val web3: Web3j, val wallets: Map<String, String>, val tok
      * @param tx transaction in block
      * @return list of notary events on ERC20 deposit
      */
-    private fun handleErc20(tx: Transaction): List<SideChainEvent> {
+    private fun handleErc20(
+        tx: Transaction,
+        wallets: Map<String, String>,
+        tokens: Map<String, String>
+    ): List<SideChainEvent> {
         // get receipt that contains data about solidity function execution
         val receipt = web3.ethGetTransactionReceipt(tx.hash).send()
+
         return receipt.transactionReceipt.get().logs
             .filter {
                 // filter out transfer
@@ -56,7 +68,7 @@ class EthChainHandler(val web3: Web3j, val wallets: Map<String, String>, val tok
      * @param tx transaction in block
      * @return list of notary events on Ether deposit
      */
-    private fun handleEther(tx: Transaction): List<SideChainEvent> {
+    private fun handleEther(tx: Transaction, wallets: Map<String, String>): List<SideChainEvent> {
         return listOf(
             SideChainEvent.EthereumEvent.OnEthSidechainDeposit(
                 tx.hash,
@@ -74,16 +86,25 @@ class EthChainHandler(val web3: Web3j, val wallets: Map<String, String>, val tok
     override fun parseBlock(block: EthBlock): List<SideChainEvent> {
         logger.info { "Eth chain handler for block ${block.block.number}" }
 
-        return block.block.transactions
-            .map { it.get() as Transaction }
-            .flatMap {
-                if (wallets.containsKey(it.to))
-                    handleEther(it)
-                else if (tokens.containsKey(it.to))
-                    handleErc20(it)
-                else
-                    listOf()
+        return ethWalletsProvider.getWallets().fanout {
+            ethTokensProvider.getTokens()
+        }.fold(
+            { (wallets, tokens) ->
+                block.block.transactions
+                    .map { it.get() as Transaction }
+                    .flatMap {
+                        if (wallets.containsKey(it.to))
+                            handleEther(it, wallets)
+                        else if (tokens.containsKey(it.to))
+                            handleErc20(it, tokens, wallets)
+                        else
+                            listOf()
+                    }
+            }, {
+                logger.error { it }
+                listOf()
             }
+        )
     }
 
     /**

--- a/src/test/integration/IntegrationTest.kt
+++ b/src/test/integration/IntegrationTest.kt
@@ -206,11 +206,10 @@ class IntegrationTest {
      * Test US-001 Deposit of ETH
      * Note: Ethereum and Iroha must be deployed to pass the test.
      * @given Ethereum and Iroha networks running and two ethereum wallets and "fromAddress" with at least
-     * 1234000000000 Wei and notary running
+     * 1234000000000 Wei and notary running and user registered with ethereum toAddress
      * @when "fromAddress" transfers 1234000000000 Wei to "toAddress"
      * @then Associated Iroha account balance is increased on 1234000000000 Wei
      */
-    @Disabled
     @Test
     fun depositOfETH() {
         val assetId = "ether#ethereum"
@@ -231,7 +230,35 @@ class IntegrationTest {
         deployHelper.sendEthereum(amount, toAddress)
         Thread.sleep(120_000)
 
-        // Send again any transaction to commit in Ethereum network
+        assertEquals(amount, queryIroha(assetId, clientIrohaAccount))
+    }
+
+    /**
+     * Test US-001 Deposit of ETH
+     * Note: Ethereum and Iroha must be deployed to pass the test.
+     * @given Ethereum and Iroha networks running and two ethereum wallets and "fromAddress" with at least
+     * 1234000000000 Wei and notary running
+     * @when Notary is running, test registers user with "toAddress" and then "fromAddress" transfers 1234000000000 Wei
+     * to "toAddress"
+     * @then Associated Iroha account balance is increased on 1234000000000 Wei
+     */
+    @Test
+    fun depositAfterAddOfETH() {
+        val assetId = "ether#ethereum"
+        val amount = BigInteger.valueOf(1_234_000_000_000)
+
+        // ensure that initial wallet value is 0
+        assertEquals(BigInteger.ZERO, queryIroha(assetId, clientIrohaAccount))
+
+        // run notary
+        async {
+            main(arrayOf())
+        }
+        Thread.sleep(3_000)
+
+        setAccountDetail("notary_red@notary", toAddress, clientIrohaAccount, testConfig.registrationIrohaAccount)
+
+        // send ETH
         deployHelper.sendEthereum(amount, toAddress)
         Thread.sleep(120_000)
 

--- a/src/test/kotlin/notary/NotaryInitializationTest.kt
+++ b/src/test/kotlin/notary/NotaryInitializationTest.kt
@@ -24,9 +24,6 @@ class NotaryInitializationTest {
             }
     }
 
-    /** Some exception message */
-    val throwMessage = "Hey, look at my exception!"
-
     /** Mock iroha configs */
     val irohaConfig = mock<IrohaConfig> {
         on { hostname } doReturn "localhost"
@@ -67,54 +64,4 @@ class NotaryInitializationTest {
     /** Mock Iroha network */
     val irohaNetwork = mock<IrohaNetwork>()
 
-    /**
-     * @given eth wallets loader and notary initializer
-     * @when eth wallets loader fails with exception
-     * @then notary initializer returns Result with reason
-     */
-    @Test
-    fun testFailToLoadWallets() {
-
-        // Wallet provider that fails with exception
-        val failEthWalletProvider = mock<EthWalletsProvider> {
-            on {
-                getWallets()
-            } doReturn Result.of { throw Exception(throwMessage) }
-        }
-
-        val notaryInit =
-            NotaryInitialization(notaryConfig, passwordConfig, failEthWalletProvider, ethTokenProvider, irohaNetwork)
-
-        notaryInit.init().fold(
-            { fail { "Exception should be thrown in wallets loader" } },
-            { exc ->
-                assertEquals(throwMessage, exc.message)
-            }
-        )
-    }
-
-    /**
-     * @given eth tokens loader and notary initializer
-     * @when eth tokens loader fails with exception
-     * @then notary initializer returns Result with reason
-     */
-    @Test
-    fun testFailToLoadTokens() {
-
-        // Token provider that fails with exception
-        val failEthTokenProvider = mock<EthTokensProvider> {
-            on {
-                getTokens()
-            } doReturn Result.of { throw Exception(throwMessage) }
-        }
-
-        val notaryInit = NotaryInitialization(notaryConfig, passwordConfig, ethWalletProvider, failEthTokenProvider)
-
-        notaryInit.init().fold(
-            { fail { "Exception should be thrown in tokens loader" } },
-            { exc ->
-                assertEquals(throwMessage, exc.message)
-            }
-        )
-    }
 }


### PR DESCRIPTION
Fix notary.
Previously provider returns the list of observable wallets and tokens on start, now we query each time eht block arrives.