### PR TITLE
Add PIT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,10 +6,13 @@ buildscript {
         mavenCentral()
         jcenter()
     }
+    configurations.maybeCreate("pitest")
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.3'
         classpath 'nu.studer:gradle-jooq-plugin:2.0.11'
+        classpath 'info.solidsoft.gradle.pitest:gradle-pitest-plugin:1.3.0'
+        pitest 'org.pitest:pitest-junit5-plugin:0.3'
     }
 }
 
@@ -22,6 +25,7 @@ apply plugin: 'com.google.protobuf'
 apply plugin: 'nu.studer.jooq'
 apply plugin: 'application'
 apply plugin: "jacoco"
+apply plugin: 'info.solidsoft.pitest'
 mainClassName = 'notary.NotaryImpl'
 
 sourceCompatibility = 1.8
@@ -354,6 +358,8 @@ processResources {
     }
 }
 
+// -------------------------| JaCoCo code coverage |-------------------------
+
 jacocoTestReport {
     reports {
         xml.enabled = true
@@ -369,4 +375,12 @@ jacocoTestReport {
                                         'integration/**'])
         })
     }
+}
+
+// -------------------------| PIT mutation testing |-------------------------
+
+pitest {
+    pitestVersion = "1.3.0"
+    testPlugin = "junit5"
+    targetClasses = ['util.*', 'notary.*']
 }

--- a/build.gradle
+++ b/build.gradle
@@ -382,5 +382,10 @@ jacocoTestReport {
 pitest {
     pitestVersion = "1.3.0"
     testPlugin = "junit5"
-    targetClasses = ['util.*', 'notary.*']
+    targetClasses = ['util.*', 'notary.*', 'registration.*', 'withdrawalservice.*']
+    excludedClasses = ['notary.db.*', '*Test*']
+    targetTests = ['util.*', 'notary.*', 'registration.*', 'withdrawalservice.*']
+    avoidCallsTo = ['kotlin.jvm.internal', 'mu']
+    mutators = ['CONDITIONALS_BOUNDARY', 'NEGATE_CONDITIONALS', 'REMOVE_CONDITIONALS', 'MATH', 'INCREMENTS',
+                'INVERT_NEGS', 'INLINE_CONSTS', 'VOID_METHOD_CALLS']
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Tue Jul 31 14:36:24 MSK 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.8-all.zip


### PR DESCRIPTION
Add mutation coverage tool [PIT](http://pitest.org/).
How to run:
```
gradle test
gradle pitest
```
See report in `build/reports/pitest`.
`gradle clean` deletes all generated reports.

It works not so well with Kotlin, I disabled mutators that check on null values. Also it generates a lot of false positive mutation with substitutions for uncovered code. But it will go away as soon as we cover it. So, we can make use of pitest.