### PR TITLE
Temporary fix for gradle image

### DIFF
--- a/deploy-relay.dockerfile
+++ b/deploy-relay.dockerfile
@@ -1,4 +1,4 @@
-FROM gradle
+FROM x3medima17/gradle
 
 ADD --chown=gradle:gradle . /build/
 RUN gradle -b /build/build.gradle assemble

--- a/notary.dockerfile
+++ b/notary.dockerfile
@@ -1,4 +1,4 @@
-FROM gradle
+FROM x3medima17/gradle
 
 ADD --chown=gradle:gradle . /build/
 RUN gradle -b /build/build.gradle assemble

--- a/registration.dockerfile
+++ b/registration.dockerfile
@@ -1,4 +1,4 @@
-FROM gradle
+FROM x3medima17/gradle
 
 ADD --chown=gradle:gradle . /build/
 RUN gradle -b /build/build.gradle assemble

--- a/withdrawal.dockerfile
+++ b/withdrawal.dockerfile
@@ -1,4 +1,4 @@
-FROM gradle
+FROM x3medima17/gradle
 
 ADD --chown=gradle:gradle . /build/
 RUN gradle -b /build/build.gradle assemble


### PR DESCRIPTION
Since `library/gradle` does not work, I built it from Dockerfile and uploaded on docker hub.

Signed-off-by: Dumitru <dimasavva17@gmail.com>