### PR TITLE
remove createAsset from notary logic

### DIFF
--- a/src/integration-test/kotlin/integration/eth/WithdrawalPipelineIntegrationTest.kt
+++ b/src/integration-test/kotlin/integration/eth/WithdrawalPipelineIntegrationTest.kt
@@ -1,7 +1,5 @@
 package integration.eth
 
-import config.EthereumPasswords
-import config.loadConfigs
 import integration.helper.IntegrationHelperUtil
 import jp.co.soramitsu.iroha.ModelCrypto
 import kotlinx.coroutines.experimental.async

--- a/src/integration-test/kotlin/integration/helper/ConfigHelper.kt
+++ b/src/integration-test/kotlin/integration/helper/ConfigHelper.kt
@@ -12,7 +12,10 @@ import withdrawalservice.WithdrawalServiceConfig
 import java.util.concurrent.atomic.AtomicInteger
 
 class ConfigHelper {
-    private val portCounter = AtomicInteger(2_000)
+
+    /** Port counter, so new port is generated for each run */
+    private val portCounter = AtomicInteger(19_999)
+
     /** Configurations for tests */
     val testConfig = loadConfigs("test", TestConfig::class.java, "/test.properties")
 
@@ -39,14 +42,13 @@ class ConfigHelper {
         loadConfigs("btc-registration", BtcRegistrationConfig::class.java, "/btc/registration.properties")
 
     /** Test configuration for Iroha */
-    fun createIrohaConfig(notaryAccount: String = "notary_red@notary"): IrohaConfig {
+    fun createIrohaConfig(creator: String = testConfig.iroha.creator): IrohaConfig {
         return object : IrohaConfig {
             override val hostname: String
                 get() = testConfig.iroha.hostname
             override val port: Int
                 get() = testConfig.iroha.port
-            override val creator: String
-                get() = notaryAccount
+            override val creator = creator
             override val pubkeyPath: String
                 get() = testConfig.iroha.pubkeyPath
             override val privkeyPath: String
@@ -131,8 +133,7 @@ class ConfigHelper {
                 get() = registrationAccount
             override val notaryIrohaAccount: String
                 get() = testConfig.notaryIrohaAccount
-            override val iroha: IrohaConfig
-                get() = ethRegistrationConfig.iroha
+            override val iroha = createIrohaConfig(creator = registrationAccount)
         }
     }
 

--- a/src/main/kotlin/notary/NotaryImpl.kt
+++ b/src/main/kotlin/notary/NotaryImpl.kt
@@ -26,7 +26,7 @@ class NotaryImpl(
 
     /**
      * Handles primary chain deposit event. Notaries create the ordered bunch of
-     * transactions:{tx1: setAccountDetail, tx2: CreateAsset, tx3: addAssetQuantity, transferAsset}.
+     * transactions: {tx1: setAccountDetail, tx2: addAssetQuantity, transferAsset}.
      * SetAccountDetail insert into notary account information about the transaction (hash) for rollback.
      */
     private fun onPrimaryChainDeposit(
@@ -49,16 +49,6 @@ class NotaryImpl(
                             creator,
                             "last_tx",
                             hash
-                        )
-                    )
-                ),
-                IrohaTransaction(
-                    creator,
-                    arrayListOf(
-                        IrohaCommand.CommandCreateAsset(
-                            asset,
-                            domain,
-                            0
                         )
                     )
                 ),

--- a/src/main/kotlin/registration/eth/EthRegistrationServiceInitialization.kt
+++ b/src/main/kotlin/registration/eth/EthRegistrationServiceInitialization.kt
@@ -2,6 +2,7 @@ package registration.eth
 
 import com.github.kittinunf.result.Result
 import com.github.kittinunf.result.map
+import mu.KLogging
 import provider.eth.EthFreeRelayProvider
 import registration.RegistrationServiceEndpoint
 import sidechain.iroha.consumer.IrohaConsumerImpl
@@ -13,6 +14,13 @@ import sidechain.iroha.util.ModelUtil
  * @param ethRegistrationConfig - configurations of registration service
  */
 class EthRegistrationServiceInitialization(private val ethRegistrationConfig: EthRegistrationConfig) {
+
+    init {
+        logger.info {
+            """Start registration service initialization with configs:
+                |iroha creator: ${ethRegistrationConfig.iroha.creator}""".trimMargin()
+        }
+    }
 
     /**
      * Init Registration Service
@@ -50,5 +58,10 @@ class EthRegistrationServiceInitialization(private val ethRegistrationConfig: Et
             Unit
         }
     }
+
+    /**
+     * Logger
+     */
+    companion object : KLogging()
 
 }

--- a/src/test/kotlin/notary/NotaryTest.kt
+++ b/src/test/kotlin/notary/NotaryTest.kt
@@ -62,17 +62,6 @@ class NotaryTest {
                         }
 
                         commands = txs[1].commands
-                        assertEquals(1, commands.size)
-                        cmd = commands.first()
-                        if (cmd is IrohaCommand.CommandCreateAsset) {
-                            assertEquals(expectedAssetId, cmd.assetName)
-                            assertEquals("ethereum", cmd.domainId)
-                            assertEquals(0, cmd.precision)
-                        } else {
-                            fail { "Wrong IrohaCommand type" }
-                        }
-
-                        commands = txs[2].commands
                         assertEquals(2, commands.size)
                         cmd = commands[0]
                         if (cmd is IrohaCommand.CommandAddAssetQuantity) {
@@ -104,10 +93,9 @@ class NotaryTest {
     /**
      * @given a custodian has 100 Wei with intention to deposit 100 Wei to Notary
      * @when a custodian transfer 100 Wei to a specified wallet and specifies Iroha wallet to deposit assets
-     * @then an IrohaOrderedBatch is emitted with 3 transactions:
+     * @then an IrohaOrderedBatch is emitted with 2 transactions:
      * 1 - SetAccountDetail with hash
-     * 2 - CreateAsset with "ether" asset name
-     * 3 - AddAssetQuantity with 100 Wei and TransferAsset with 100 Wei to specified account id
+     * 2 - AddAssetQuantity with 100 Wei and TransferAsset with 100 Wei to specified account id
      */
     @Test
     fun depositEthereumTest() {
@@ -144,10 +132,9 @@ class NotaryTest {
     /**
      * @given a custodian has 100 "XOR" ERC20 tokens with intention to deposit 100 "XOR" tokens to Notary
      * @when a custodian transfer 100 "XOR" tokens to a specified wallet and specifies Iroha wallet to deposit assets
-     * @then an IrohaOrderedBatch is emitted with 3 transactions:
+     * @then an IrohaOrderedBatch is emitted with 2 transactions:
      * 1 - SetAccountDetail with hash
-     * 2 - CreateAsset with "XOR" asset name
-     * 3 - AddAssetQuantity with 100 "XOR" and TransferAsset with 100 "XOR" to specified account id
+     * 2 - AddAssetQuantity with 100 "XOR" and TransferAsset with 100 "XOR" to specified account id
      */
     @Test
     fun depositEthereumTokenTest() {


### PR DESCRIPTION
Remove CreateAsset from notary deposit pipeline.
Fix integration test configs.

Signed-off-by: Alexey Chernyshov <alexey.n.chernyshov@gmail.com>