### PR TITLE
Add withdrawal tests for cases with many peers

### DIFF
--- a/src/integration-test/resources/test.properties
+++ b/src/integration-test/resources/test.properties
@@ -25,7 +25,7 @@ test.ethereum.credentialsPath=deploy/ethereum/keys/ganache.key
 # Gas price for relay contract deployment
 test.ethereum.gasPrice=1
 # Gas limit for relay contract deployment
-test.ethereum.gasLimit=1999999
+test.ethereum.gasLimit=6000000
 # --------- Bitcoin ---------
 test.bitcoin.walletPath=deploy/bitcoin/test-btc.wallet
 test.bitcoin.blockStoragePath=deploy/bitcoin/blocks

--- a/src/integration-test/resources/test_deploy.properties
+++ b/src/integration-test/resources/test_deploy.properties
@@ -25,7 +25,7 @@ test.ethereum.credentialsPath=deploy/ethereum/keys/user.key
 # Gas price for relay contract deployment
 test.ethereum.gasPrice=1
 # Gas limit for relay contract deployment
-test.ethereum.gasLimit=1999999
+test.ethereum.gasLimit=6000000
 # --------- Bitcoin ---------
 test.bitcoin.walletPath=deploy/bitcoin/test-btc.wallet
 test.bitcoin.blockStoragePath=deploy/bitcoin/blocks


### PR DESCRIPTION
Now we have tests for withdrawal with many peers and many signatures. Also tests code was refactored a bit.