### PR TITLE
Feature/iroha block streaming interface

### DIFF
--- a/src/integration-test/kotlin/integration/iroha/IrohaBatchTest.kt
+++ b/src/integration-test/kotlin/integration/iroha/IrohaBatchTest.kt
@@ -1,7 +1,6 @@
-package integration
+package integration.iroha
 
 import config.loadConfigs
-import io.reactivex.schedulers.Schedulers
 import jp.co.soramitsu.iroha.Blob
 import jp.co.soramitsu.iroha.ModelCrypto
 import jp.co.soramitsu.iroha.ModelQueryBuilder
@@ -14,7 +13,6 @@ import notary.IrohaOrderedBatch
 import notary.IrohaTransaction
 import notary.eth.EthNotaryConfig
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.fail
 import sidechain.iroha.IrohaChainListener
@@ -60,7 +58,6 @@ class IrohaBatchTest {
      * @when All transactions are valid and sent as a batch
      * @then They all are accepted and committed in the same block
      */
-    @Disabled
     @Test
     fun allValidBatchTest() {
 
@@ -121,19 +118,17 @@ class IrohaBatchTest {
         )
         val lst = IrohaConverterImpl().convert(batch)
         val hashes = lst.map { it.hash().hex() }
-        var blockHashes: List<String>? = null
 
-        IrohaChainListener(
+        val listener = IrohaChainListener(
             testConfig.iroha.hostname,
             testConfig.iroha.port,
             tester, keypair
-        ).getBlockObservable().get().map { block ->
-            val txs = block.payload.transactionsList
-
-            blockHashes = txs.map {
+        )
+        val blockHashes = async {
+            listener.getBlock().payload.transactionsList.map {
                 Blob(iroha.hashTransaction(it.toByteArray().toByteVector())).hex()
             }
-        }.subscribeOn(Schedulers.io()).subscribe()
+        }
 
 
         val successHash = irohaConsumer.sendAndCheck(lst).get()
@@ -220,13 +215,10 @@ class IrohaBatchTest {
         assertEquals(tester_amount.toInt(), 73)
         assertEquals(u1_amount.toInt(), 27)
 
-        val scope = async {
-            while (blockHashes == null);
-            assertEquals(hashes, blockHashes)
-
-        }
         runBlocking {
-            withTimeout(10, TimeUnit.SECONDS) { scope.await() }
+            withTimeout(10, TimeUnit.SECONDS) {
+                assertEquals(hashes, blockHashes.await())
+            }
         }
     }
 
@@ -235,7 +227,6 @@ class IrohaBatchTest {
      * @when Not all transactions are valid and sent as a batch
      * @then Only valid are accepted and committed in the same block
      */
-    @Disabled
     @Test
     fun notAllValidBatchTest() {
         val user = randomString()
@@ -308,19 +299,18 @@ class IrohaBatchTest {
         val lst = IrohaConverterImpl().convert(batch)
         val hashes = lst.map { it.hash().hex() }
         val expectedHashes = hashes.subList(0, hashes.size - 1)
-        var blockHashes: List<String>? = null
 
-        IrohaChainListener(
+
+        val listener = IrohaChainListener(
             testConfig.iroha.hostname,
             testConfig.iroha.port,
             tester, keypair
-        ).getBlockObservable().get().map { block ->
-            val txs = block.payload.transactionsList
-
-            blockHashes = txs.map {
+        )
+        val blockHashes = async {
+            listener.getBlock().payload.transactionsList.map {
                 Blob(iroha.hashTransaction(it.toByteArray().toByteVector())).hex()
             }
-        }.subscribeOn(Schedulers.io()).subscribe()
+        }
 
 
         val successHash = irohaConsumer.sendAndCheck(lst).get()
@@ -407,13 +397,10 @@ class IrohaBatchTest {
         assertEquals(tester_amount.toInt(), 73)
         assertEquals(u1_amount.toInt(), 27)
 
-        val scope = async {
-            while (blockHashes == null);
-            assertEquals(expectedHashes, blockHashes)
-
-        }
         runBlocking {
-            withTimeout(10, TimeUnit.SECONDS) { scope.await() }
+            withTimeout(10, TimeUnit.SECONDS) {
+                assertEquals(expectedHashes, blockHashes.await())
+            }
         }
     }
 }

--- a/src/integration-test/kotlin/integration/iroha/IrohaBlockStreamingTest.kt
+++ b/src/integration-test/kotlin/integration/iroha/IrohaBlockStreamingTest.kt
@@ -46,7 +46,6 @@ class IrohaBlockStreamingTest {
      * @when new tx is sent to Iroha
      * @then block arrived to IrohaListener
      */
-//    @Disabled
     @Test
     fun irohaStreamingTest() {
         var cmds = listOf<iroha.protocol.Commands.Command>()

--- a/src/main/kotlin/sidechain/ChainListener.kt
+++ b/src/main/kotlin/sidechain/ChainListener.kt
@@ -12,4 +12,9 @@ interface ChainListener<Block> {
      */
     fun getBlockObservable(): Result<io.reactivex.Observable<Block>, Exception>
 
+    /**
+     * @return a block that was committed into network
+     */
+    suspend fun getBlock(): Block;
+
 }

--- a/src/main/kotlin/sidechain/eth/EthChainListener.kt
+++ b/src/main/kotlin/sidechain/eth/EthChainListener.kt
@@ -49,6 +49,10 @@ class EthChainListener(
         }
     }
 
+    override suspend fun getBlock(): EthBlock {
+        throw TODO("Implement eth get block with coroutines");
+    }
+
     /**
      * Logger
      */


### PR DESCRIPTION
Many times we have to wait for exactly one block from iroha, usually we need it in tests.
Using block streaming service and RxJava is an overkill, this PR introduces a suspended function that waits for exactly one block and returns it.