### PR TITLE
Revert protobuf back to 3.5.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ repositories {
 
 dependencies {
     // protobuf
-    compile 'com.google.protobuf:protobuf-java:3.6.1'
+    compile 'com.google.protobuf:protobuf-java:3.5.1'
     compile 'io.grpc:grpc-netty:1.14.0'
     compile 'io.grpc:grpc-protobuf:1.14.0'
     compile 'io.grpc:grpc-stub:1.14.0'
@@ -188,7 +188,7 @@ run {
 
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:3.6.1"
+        artifact = "com.google.protobuf:protoc:3.5.1"
     }
     plugins {
         grpc {


### PR DESCRIPTION
Just because iroha still uses 3.5.1.