### PR TITLE
Fixed build script to run old junit tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -114,6 +114,8 @@ dependencies {
 
     // for setting env variables in tests
     testCompile group: 'com.github.stefanbirkner', name: 'system-rules', version: '1.18.0'
+    // to run both junit4 and junit5 tests
+    testRuntime("org.junit.vintage:junit-vintage-engine:5.2.0")
 
 }
 


### PR DESCRIPTION
We have tests based on junit4 and these tests are not executed by default. We must provide additional migration dependency to run both junit4 and junit5 tests from gradle.