### PR TITLE
Remove coroutines, since they are not needed here

### DIFF
--- a/notary-integration-test/src/integration-test/kotlin/integration/eth/WithdrawalPipelineIntegrationTest.kt
+++ b/notary-integration-test/src/integration-test/kotlin/integration/eth/WithdrawalPipelineIntegrationTest.kt
@@ -3,9 +3,10 @@ package integration.eth
 import integration.helper.IntegrationHelperUtil
 import jp.co.soramitsu.iroha.Keypair
 import jp.co.soramitsu.iroha.ModelCrypto
-import kotlinx.coroutines.experimental.Job
-import kotlinx.coroutines.experimental.launch
-import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
 import provider.eth.ETH_PRECISION
 import util.getRandomString
 import java.math.BigDecimal
@@ -42,18 +43,12 @@ class WithdrawalPipelineIntegrationTest {
     /** Notary account in Iroha */
     private val notaryAccount = withdrawalServiceConfig.notaryIrohaAccount
 
-    private val registrationService: Job
-
-    private val withdrawalService: Job
-
     init {
         integrationHelper.runEthNotary(notaryConfig)
-        registrationService = launch {
-            registration.eth.executeRegistration(registrationConfig, passwordConfig)
-        }
-        withdrawalService = launch {
-            withdrawalservice.executeWithdrawal(withdrawalServiceConfig, passwordConfig)
-        }
+        registration.eth.executeRegistration(registrationConfig, passwordConfig)
+
+        withdrawalservice.executeWithdrawal(withdrawalServiceConfig, passwordConfig)
+
         Thread.sleep(10_000)
     }
 
@@ -67,12 +62,6 @@ class WithdrawalPipelineIntegrationTest {
         clientName = String.getRandomString(9)
         clientId = "$clientName@notary"
         keypair = ModelCrypto().generateKeypair()
-    }
-
-    @AfterAll
-    fun dropDown() {
-        registrationService.cancel()
-        withdrawalService.cancel()
     }
 
     /**

--- a/src/main/kotlin/withdrawalservice/WithdrawalServiceInitialization.kt
+++ b/src/main/kotlin/withdrawalservice/WithdrawalServiceInitialization.kt
@@ -13,7 +13,6 @@ import sidechain.eth.consumer.EthConsumer
 import sidechain.iroha.IrohaChainHandler
 import sidechain.iroha.IrohaChainListener
 import sidechain.iroha.consumer.IrohaNetworkImpl
-import sidechain.iroha.util.ModelUtil
 
 /**
  * @param withdrawalConfig - configuration for withdrawal service
@@ -56,6 +55,7 @@ class WithdrawalServiceInitialization(
         return Result.of {
             val ethConsumer = EthConsumer(withdrawalConfig.ethereum, withdrawalEthereumPasswords)
             withdrawalService.output()
+                .subscribeOn(io.reactivex.schedulers.Schedulers.io())
                 .subscribe(
                     { res ->
                         res.map { withdrawalEvents ->

--- a/src/test/kotlin/registration/RegistrationTest.kt
+++ b/src/test/kotlin/registration/RegistrationTest.kt
@@ -4,9 +4,6 @@ import com.github.kittinunf.result.Result
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
 import io.ktor.http.HttpStatusCode
-import kotlinx.coroutines.experimental.Job
-import kotlinx.coroutines.experimental.launch
-import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -40,19 +37,11 @@ open class RegistrationTest {
         } doReturn Result.of { correctEthWallet }
     }
 
-    private val registrationService: Job
-
     init {
-        registrationService = launch {
-            RegistrationServiceEndpoint(port, strategy)
-        }
+
+        RegistrationServiceEndpoint(port, strategy)
 
         Thread.sleep(3_000)
-    }
-
-    @AfterAll
-    fun dropDown() {
-        registrationService.cancel()
     }
 
     /**


### PR DESCRIPTION
Remove courotines from `WithdrawalPipelineIntegrationTest`
Set separate thread for `EthConsumer`

Signed-off-by: Dumitru <dimasavva17@gmail.com>