### PR TITLE
Implement closeable in Eth and Iroha chain listeners

### DIFF
--- a/src/main/kotlin/sidechain/ChainListener.kt
+++ b/src/main/kotlin/sidechain/ChainListener.kt
@@ -1,11 +1,12 @@
 package sidechain
 
 import com.github.kittinunf.result.Result
+import java.io.Closeable
 
 /**
  * Class listens for new [Block] in side block chain
  */
-interface ChainListener<Block> {
+interface ChainListener<Block> : Closeable {
 
     /**
      * @return Observable on blocks that committed to the network
@@ -15,6 +16,6 @@ interface ChainListener<Block> {
     /**
      * @return a block that was committed into network
      */
-    suspend fun getBlock(): Block;
+    suspend fun getBlock(): Block
 
 }

--- a/src/main/kotlin/sidechain/eth/EthChainListener.kt
+++ b/src/main/kotlin/sidechain/eth/EthChainListener.kt
@@ -54,6 +54,10 @@ class EthChainListener(
         return getBlockObservable().get().blockingFirst()
     }
 
+    override fun close() {
+        web3.shutdown()
+    }
+    
     /**
      * Logger
      */


### PR DESCRIPTION
ChainListener should be closeable because it acquires some resources.
This PR implements this interface for Ethereum and Iroha

Signed-off-by: Dumitru <dimasavva17@gmail.com>