### PR TITLE
Validation rules for configurations

### DIFF
--- a/configs/btc/notary_local.properties
+++ b/configs/btc/notary_local.properties
@@ -14,12 +14,6 @@ btc-notary.notaryCredential.privkeyPath=deploy/iroha/keys/notary@notary.priv
 btc-notary.iroha.hostname=d3-iroha
 # Iroha peer port
 btc-notary.iroha.port=50051
-# Notary account in Iroha
-btc-notary.iroha.creator=notary@notary
-# Path to public key
-btc-notary.iroha.pubkeyPath=deploy/iroha/keys/admin@notary.pub
-# Path to private key
-btc-notary.iroha.privkeyPath=deploy/iroha/keys/admin@notary.priv
 # --------- Bitcoin ---------
 btc-notary.bitcoin.walletPath=deploy/bitcoin/regtest/d3.wallet
 btc-notary.bitcoin.blockStoragePath=deploy/bitcoin/regtest/blocks

--- a/configs/btc/notary_testnet.properties
+++ b/configs/btc/notary_testnet.properties
@@ -14,12 +14,6 @@ btc-notary.notaryCredential.privkeyPath=deploy/iroha/keys/notary@notary.priv
 btc-notary.iroha.hostname=d3-iroha
 # Iroha peer port
 btc-notary.iroha.port=50051
-# Notary account in Iroha
-btc-notary.iroha.creator=notary@notary
-# Path to public key
-btc-notary.iroha.pubkeyPath=deploy/iroha/keys/admin@notary.pub
-# Path to private key
-btc-notary.iroha.privkeyPath=deploy/iroha/keys/admin@notary.priv
 # --------- Bitcoin ---------
 btc-notary.bitcoin.walletPath=deploy/bitcoin/testnet/d3.wallet
 btc-notary.bitcoin.blockStoragePath=deploy/bitcoin/testnet/blocks

--- a/src/main/kotlin/config/ConfigValidator.kt
+++ b/src/main/kotlin/config/ConfigValidator.kt
@@ -1,0 +1,6 @@
+package config
+
+interface ConfigValidationRule<T> {
+    /* Validation rule itself. Must throw IllegalArgumentException in case of validation violations*/
+    fun validate(config: T)
+}

--- a/src/main/kotlin/config/Configs.kt
+++ b/src/main/kotlin/config/Configs.kt
@@ -89,13 +89,20 @@ fun getProfile(): String {
 /**
  * Load configs from Java properties
  */
-fun <T : Any> loadConfigs(prefix: String, type: Class<T>, filename: String): T {
+fun <T : Any> loadConfigs(
+    prefix: String,
+    type: Class<T>,
+    filename: String,
+    vararg validators: ConfigValidationRule<T>
+): T {
     val profile = getProfile()
     val (file, extension) = filename.split(".")
     val pwd = System.getProperty("user.dir")
     val path = "$pwd/configs${file}_$profile.$extension"
     logger.info { "Loading config from $path, prefix $prefix" }
-    return loadRawConfigs(prefix, type, path)
+    val config = loadRawConfigs(prefix, type, path)
+    validators.forEach { rule -> rule.validate(config) }
+    return config
 }
 
 class Stream(private val stream: InputStream) : ConfigSource {

--- a/src/test/kotlin/config/ConfigsPriorityTest.kt
+++ b/src/test/kotlin/config/ConfigsPriorityTest.kt
@@ -6,7 +6,7 @@ import org.junit.Test
 import org.junit.contrib.java.lang.system.EnvironmentVariables
 
 
-class ConfigsTest {
+class ConfigsPriorityTest {
 
     @Rule
     @JvmField

--- a/src/test/kotlin/config/TestConfig.kt
+++ b/src/test/kotlin/config/TestConfig.kt
@@ -1,0 +1,12 @@
+package config
+
+import config.EthereumConfig
+import config.IrohaConfig
+import config.IrohaCredentialConfig
+
+interface TestConfig {
+    val ethTestAccount: String
+    val ethereum: EthereumConfig
+    val iroha: IrohaConfig
+    val testCredentialConfig: IrohaCredentialConfig
+}


### PR DESCRIPTION
Now we can set validation rules for an arbitrary configuration. By the contract(see ConfigValidationRule) validation rule must throw IllegalArgumentException if configuration violates validation logic. 