### PR TITLE
Split compose file

### DIFF
--- a/deploy/docker-compose-base.yml
+++ b/deploy/docker-compose-base.yml
@@ -1,0 +1,41 @@
+version: '3'
+
+services:
+  d3-iroha:
+    image: hyperledger/iroha:develop
+    container_name: d3-iroha
+    ports:
+      - 50051:50051
+      - 10001:10001
+    depends_on:
+      - d3-iroha-postgres
+    tty: true
+    environment:
+      - KEY=keys/node0
+    entrypoint:
+      - /opt/iroha_data/entrypoint.sh
+    volumes:
+      - iroha_block_store:/tmp/block_store
+      - ./iroha:/opt/iroha_data
+    networks:
+      - d3-network
+
+  d3-iroha-postgres:
+    image: postgres:9.5
+    container_name: d3-iroha-postgres
+    environment:
+      - POSTGRES_PASSWORD=mysecretpassword
+    expose:
+      - 5432
+    volumes:
+      - /var/lib/postgresql/data
+    networks:
+      - d3-network
+
+volumes:
+  iroha_block_store:
+
+
+networks:
+  d3-network:
+

--- a/deploy/docker-compose-full.yml
+++ b/deploy/docker-compose-full.yml
@@ -1,65 +1,6 @@
 version: '3'
 
 services:
-  d3-iroha:
-    image: hyperledger/iroha:develop
-    container_name: d3-iroha
-    ports:
-      - 50051:50051
-      - 10001:10001
-    depends_on:
-      - d3-iroha-postgres
-    tty: true
-    environment:
-      - KEY=keys/node0
-    entrypoint:
-      - /opt/iroha_data/entrypoint.sh
-    volumes:
-      - iroha_block_store:/tmp/block_store
-      - ./iroha:/opt/iroha_data
-
-  d3-iroha-postgres:
-    image: postgres:9.5
-    container_name: d3-iroha-postgres
-    environment:
-      - POSTGRES_PASSWORD=mysecretpassword
-    expose:
-      - 5432
-    volumes:
-      - /var/lib/postgresql/data
-
-  d3-eth-relay:
-    image: nexus.iroha.tech:19002/d3-deploy/eth-relay:${TAG}
-    container_name: d3-eth-relay
-    depends_on:
-      - d3-iroha
-    volumes:
-      - ./:/opt/notary/deploy
-      - ../configs:/opt/notary/configs
-    environment:
-      - PROFILE
-      - IROHA_HOST=d3-iroha
-      - IROHA_PORT=50051
-      - CLASS=registration.eth.relay.DeployRelayMain
-
-
-  d3-registration:
-    image: nexus.iroha.tech:19002/d3-deploy/registration:${TAG}
-    container_name: d3-registration
-    depends_on:
-      - d3-iroha
-     # - d3-eth-node0
-    ports:
-      - 8083:8083
-    volumes:
-      - ./:/opt/notary/deploy
-      - ../configs:/opt/notary/configs
-    environment:
-      - PROFILE
-      - IROHA_HOST=d3-iroha
-      - IROHA_PORT=50051
-      - CLASS=registration.eth.EthRegistrationMain
-
   d3-notary:
     image: nexus.iroha.tech:19002/d3-deploy/notary:${TAG}
     container_name: d3-notary
@@ -75,35 +16,6 @@ services:
       - IROHA_HOST=d3-iroha
       - IROHA_PORT=50051
       - CLASS=notary.eth.EthNotaryMain
-
-  d3-withdrawal:
-    image: nexus.iroha.tech:19002/d3-deploy/withdrawal:${TAG}
-    container_name: d3-withdrawal
-    depends_on:
-      - d3-iroha
-    volumes:
-      - ./:/opt/notary/deploy
-      - ../configs:/opt/notary/configs
-    environment:
-      - PROFILE
-      - IROHA_HOST=d3-iroha
-      - IROHA_PORT=50051
-      - CLASS=withdrawalservice.WithdrawalServiceMain
-
-  grpcwebproxy:
-    image: nexus.iroha.tech:19002/d3-deploy/grpcwebproxy
-    container_name: d3-grpcwebproxy
-    depends_on:
-      - d3-iroha
-    ports:
-      - 8081:8080
-      - 8443:8443
-    entrypoint:
-      - grpcwebproxy
-      - --backend_addr=d3-iroha:50051
-      - --run_tls_server=false
-
-
-volumes:
-  iroha_block_store:
+    networks:
+      - d3-network
 

--- a/deploy/docker-compose-full.yml
+++ b/deploy/docker-compose-full.yml
@@ -19,3 +19,16 @@ services:
     networks:
       - d3-network
 
+
+  grpcwebproxy:
+    image: nexus.iroha.tech:19002/d3-deploy/grpcwebproxy
+    container_name: d3-grpcwebproxy
+    ports:
+      - 8081:8080
+      - 8443:8443
+    entrypoint:
+      - grpcwebproxy
+      - --backend_addr=d3-iroha:50051
+      - --run_tls_server=false
+    networks:
+      - d3-network

--- a/deploy/docker-compose-full.yml
+++ b/deploy/docker-compose-full.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   d3-notary:
-    image: nexus.iroha.tech:19002/d3-deploy/notary:${TAG}
+    image: nexus.iroha.tech:19002/d3-deploy/notary:${TAG:-master}
     container_name: d3-notary
     depends_on:
       - d3-iroha

--- a/deploy/docker-compose-single.yml
+++ b/deploy/docker-compose-single.yml
@@ -48,19 +48,5 @@ services:
       - d3-network
 
 
-  grpcwebproxy:
-    image: nexus.iroha.tech:19002/d3-deploy/grpcwebproxy
-    container_name: d3-grpcwebproxy
-    ports:
-      - 8081:8080
-      - 8443:8443
-    entrypoint:
-      - grpcwebproxy
-      - --backend_addr=d3-iroha:50051
-      - --run_tls_server=false
-    networks:
-      - d3-network
-
-
 networks:
   d3-network:

--- a/deploy/docker-compose-single.yml
+++ b/deploy/docker-compose-single.yml
@@ -1,0 +1,66 @@
+version: '3'
+
+
+services:
+  d3-eth-relay:
+    image: nexus.iroha.tech:19002/d3-deploy/eth-relay:${TAG}
+    container_name: d3-eth-relay
+    volumes:
+      - ./:/opt/notary/deploy
+      - ../configs:/opt/notary/configs
+    environment:
+      - PROFILE
+      - IROHA_HOST=d3-iroha
+      - IROHA_PORT=50051
+      - CLASS=registration.eth.relay.DeployRelayMain
+    networks:
+      - d3-network
+
+
+  d3-registration:
+    image: nexus.iroha.tech:19002/d3-deploy/registration:${TAG}
+    container_name: d3-registration
+    ports:
+      - 8083:8083
+    volumes:
+      - ./:/opt/notary/deploy
+      - ../configs:/opt/notary/configs
+    environment:
+      - PROFILE
+      - IROHA_HOST=d3-iroha
+      - IROHA_PORT=50051
+      - CLASS=registration.eth.EthRegistrationMain
+    networks:
+      - d3-network
+
+  d3-withdrawal:
+    image: nexus.iroha.tech:19002/d3-deploy/withdrawal:${TAG}
+    container_name: d3-withdrawal
+    volumes:
+      - ./:/opt/notary/deploy
+      - ../configs:/opt/notary/configs
+    environment:
+      - PROFILE
+      - IROHA_HOST=d3-iroha
+      - IROHA_PORT=50051
+      - CLASS=withdrawalservice.WithdrawalServiceMain
+    networks:
+      - d3-network
+
+
+  grpcwebproxy:
+    image: nexus.iroha.tech:19002/d3-deploy/grpcwebproxy
+    container_name: d3-grpcwebproxy
+    ports:
+      - 8081:8080
+      - 8443:8443
+    entrypoint:
+      - grpcwebproxy
+      - --backend_addr=d3-iroha:50051
+      - --run_tls_server=false
+    networks:
+      - d3-network
+
+
+networks:
+  d3-network:

--- a/deploy/docker-compose-single.yml
+++ b/deploy/docker-compose-single.yml
@@ -3,7 +3,7 @@ version: '3'
 
 services:
   d3-eth-relay:
-    image: nexus.iroha.tech:19002/d3-deploy/eth-relay:${TAG}
+    image: nexus.iroha.tech:19002/d3-deploy/eth-relay:${TAG-master}
     container_name: d3-eth-relay
     volumes:
       - ./:/opt/notary/deploy
@@ -18,7 +18,7 @@ services:
 
 
   d3-registration:
-    image: nexus.iroha.tech:19002/d3-deploy/registration:${TAG}
+    image: nexus.iroha.tech:19002/d3-deploy/registration:${TAG-master}
     container_name: d3-registration
     ports:
       - 8083:8083
@@ -34,7 +34,7 @@ services:
       - d3-network
 
   d3-withdrawal:
-    image: nexus.iroha.tech:19002/d3-deploy/withdrawal:${TAG}
+    image: nexus.iroha.tech:19002/d3-deploy/withdrawal:${TAG-master}
     container_name: d3-withdrawal
     volumes:
       - ./:/opt/notary/deploy


### PR DESCRIPTION
This PR adds some flexibility for deploying our services.
If we want to run a full node, with all the services:
` PROFILE=testnet TAG=debug docker-compose -f deploy/docker-compose-base.yml -f deploy/docker-compose-full.yml -f deploy/docker-compose-single.yml  up`
To run only the services that have to be deployed on each node of the network
`PROFILE=testnet TAG=debug docker-compose -f deploy/docker-compose-base.yml -f deploy/docker-compose-full.yml  up`
To run only the services that have to deployed only once per network:
`PROFILE=testnet TAG=debug docker-compose -f deploy/docker-compose-base.yml -f deploy/docker-compose-single.yml  up`

Signed-off-by: Dumitru <dimasavva17@gmail.com>