### PR TITLE
Closing IrohaNetwork using Spring

### DIFF
--- a/btc-deposit/src/main/kotlin/notary/btc/config/BtcNotaryAppConfiguration.kt
+++ b/btc-deposit/src/main/kotlin/notary/btc/config/BtcNotaryAppConfiguration.kt
@@ -17,7 +17,6 @@ class BtcNotaryAppConfiguration {
     fun notaryConfig() = notaryConfig
 
     @Bean
-    // TODO add annotation @PreDestroy in order to close()
     fun irohaNetwork() = IrohaNetworkImpl(notaryConfig.iroha.hostname, notaryConfig.iroha.port)
 
     @Bean


### PR DESCRIPTION
This pr shows how easely IrohaNetwork may be closed using Spring framework. No actions required, because Spring closes Closeables by itself. 