### PR TITLE
Bitcoin wallet is ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,4 @@ deploy/bitcoin/testnet/d3.wallet
 deploy/bitcoin/testnet/blocks
 deploy/bitcoin/regtest/blocks
 deploy/bitcoin/regtest/d3.wallet
+deploy/bitcoin/regtest/d3-test.wallet

--- a/notary-integration-test/src/main/kotlin/integration/helper/ConfigHelper.kt
+++ b/notary-integration-test/src/main/kotlin/integration/helper/ConfigHelper.kt
@@ -12,6 +12,9 @@ import registration.eth.relay.RelayRegistrationConfig
 import token.ERC20TokenRegistrationConfig
 import vacuum.RelayVacuumConfig
 import withdrawalservice.WithdrawalServiceConfig
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
 import java.util.concurrent.atomic.AtomicInteger
 
 /**
@@ -71,9 +74,23 @@ class ConfigHelper(
             override val pubKeyTriggerAccount = btcPkPreGenConfig.pubKeyTriggerAccount
             override val notaryAccount = accountHelper.notaryAccount.accountId
             override val iroha = createIrohaConfig()
-            override val btcWalletFilePath = btcPkPreGenConfig.btcWalletFilePath
+            override val btcWalletFilePath = createTempWalletFile(btcPkPreGenConfig.btcWalletFilePath)
             override val registrationAccount = accountHelper.createCredentialConfig(accountHelper.registrationAccount)
         }
+    }
+
+    /*
+        Creates temporary copy of wallet file just for testing
+     */
+    fun createTempWalletFile(btcWalletPath: String): String {
+        val newWalletFilePath = btcWalletPath.replaceFirst(".wallet", "-test.wallet")
+        val walletFile = File(newWalletFilePath)
+        if (!walletFile.exists()) {
+            val src = FileInputStream(btcWalletPath).channel
+            val dest = FileOutputStream(newWalletFilePath).channel
+            dest.transferFrom(src, 0, src.size())
+        }
+        return newWalletFilePath
     }
 
     /** Creates config for ETH relays registration */
@@ -117,10 +134,19 @@ class ConfigHelper(
             override val healthCheckPort = btcNotaryConfig.healthCheckPort
             override val registrationAccount = accountHelper.registrationAccount.accountId
             override val iroha = createIrohaConfig()
-            override val bitcoin = btcNotaryConfig.bitcoin
+            override val bitcoin = createBitcoinConfig(btcNotaryConfig.bitcoin)
             override val notaryListStorageAccount = accountHelper.notaryListStorageAccount.accountId
             override val notaryListSetterAccount = accountHelper.notaryListSetterAccount.accountId
             override val notaryCredential = accountHelper.createCredentialConfig(accountHelper.notaryAccount)
+        }
+    }
+
+    private fun createBitcoinConfig(bitcoinConfig: BitcoinConfig): BitcoinConfig {
+        return object : BitcoinConfig {
+            override val walletPath = createTempWalletFile(bitcoinConfig.walletPath)
+            override val blockStoragePath = bitcoinConfig.blockStoragePath
+            override val confidenceLevel = bitcoinConfig.confidenceLevel
+            override val host = bitcoinConfig.host
         }
     }
 

--- a/notary-integration-test/src/main/kotlin/integration/helper/ConfigHelper.kt
+++ b/notary-integration-test/src/main/kotlin/integration/helper/ConfigHelper.kt
@@ -86,9 +86,12 @@ class ConfigHelper(
         val newWalletFilePath = btcWalletPath.replaceFirst(".wallet", "-test.wallet")
         val walletFile = File(newWalletFilePath)
         if (!walletFile.exists()) {
-            val src = FileInputStream(btcWalletPath).channel
-            val dest = FileOutputStream(newWalletFilePath).channel
-            dest.transferFrom(src, 0, src.size())
+            FileInputStream(btcWalletPath).use { src ->
+                FileOutputStream(newWalletFilePath).use { dest ->
+                    val srcChannel = src.channel
+                    dest.channel.transferFrom(srcChannel, 0, srcChannel.size())
+                }
+            }
         }
         return newWalletFilePath
     }


### PR DESCRIPTION
We had a problem with bitcoin wallet file being tracked by git even with well configured `.gitignore`. Git tracks wallet file because it was commited in the past. We cannot remove this file, because it's needed to run integration tests. The simpliest workaround is creating ignored temporary copy of wallet file every time we run bitcoin tests.  