### PR TITLE
Sending transactions into Bitcoin network

### DIFF
--- a/btc-withdrawal/src/main/kotlin/withdrawal/btc/BtcWithdrawalInitialization.kt
+++ b/btc-withdrawal/src/main/kotlin/withdrawal/btc/BtcWithdrawalInitialization.kt
@@ -39,7 +39,7 @@ class BtcWithdrawalInitialization(
     fun init(): Result<Unit, Exception> {
         val wallet = Wallet.loadFromFile(File(btcWithdrawalConfig.bitcoin.walletPath))
         return initBtcBlockChain(wallet).flatMap { peerGroup ->
-            initTransferListener(
+            initWithdrawalTransferListener(
                 wallet,
                 irohaChainListener,
                 peerGroup
@@ -52,7 +52,7 @@ class BtcWithdrawalInitialization(
      * @param irohaChainListener - listener of Iroha blockchain
      * @return result of initiation process
      */
-    private fun initTransferListener(
+    private fun initWithdrawalTransferListener(
         wallet: Wallet,
         irohaChainListener: IrohaChainListener,
         peerGroup: PeerGroup

--- a/btc-withdrawal/src/main/kotlin/withdrawal/btc/config/BtcWithdrawalAppConfiguration.kt
+++ b/btc-withdrawal/src/main/kotlin/withdrawal/btc/config/BtcWithdrawalAppConfiguration.kt
@@ -11,9 +11,7 @@ import sidechain.iroha.IrohaChainListener
 import sidechain.iroha.consumer.IrohaConsumerImpl
 import sidechain.iroha.consumer.IrohaNetworkImpl
 import sidechain.iroha.util.ModelUtil
-import withdrawal.btc.BtcWhiteListProvider
-import withdrawal.transaction.SignCollector
-import withdrawal.transaction.TransactionSigner
+import withdrawal.btc.provider.BtcWhiteListProvider
 
 val withdrawalConfig = loadConfigs("btc-withdrawal", BtcWithdrawalConfig::class.java, "/btc/withdrawal.properties")
 
@@ -65,19 +63,11 @@ class BtcWithdrawalAppConfiguration {
     }
 
     @Bean
-    fun whiteListProvider() {
-        BtcWhiteListProvider(
+    fun whiteListProvider(): BtcWhiteListProvider {
+        return BtcWhiteListProvider(
             withdrawalConfig.registrationAccount,
             withdrawalCredential(),
             irohaNetwork()
         )
     }
-
-    @Bean
-    fun transactionSigner() = TransactionSigner(btcRegisteredAddressesProvider())
-
-    @Bean
-    fun signCollector() =
-        SignCollector(irohaNetwork(), withdrawalCredential(), withdrawalConsumer(), transactionSigner())
-
 }

--- a/btc-withdrawal/src/main/kotlin/withdrawal/btc/handler/NewSignatureEventHandler.kt
+++ b/btc-withdrawal/src/main/kotlin/withdrawal/btc/handler/NewSignatureEventHandler.kt
@@ -1,0 +1,57 @@
+package withdrawal.btc.handler
+
+import iroha.protocol.Commands
+import mu.KLogging
+import org.bitcoinj.core.PeerGroup
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+import sidechain.iroha.BTC_SIGN_COLLECT_DOMAIN
+import withdrawal.btc.transaction.SignCollector
+import withdrawal.btc.transaction.UnsignedTransactions
+
+/*
+    Class that is used to handle new input signature appearance events
+ */
+@Component
+class NewSignatureEventHandler(
+    @Autowired private val signCollector: SignCollector,
+    @Autowired private val unsignedTransactions: UnsignedTransactions
+) {
+
+    /**
+     * Handles "add new input signatures" commands
+     * @param addNewSignatureCommand - command object full of signatures
+     * @param peerGroup - group of Bitcoin peers. Used to broadcast withdraw transactions.
+     */
+    fun handleNewSignatureCommand(addNewSignatureCommand: Commands.SetAccountDetail, peerGroup: PeerGroup) {
+        val shortTxHash = addNewSignatureCommand.accountId.replace("@$BTC_SIGN_COLLECT_DOMAIN", "")
+        val unsignedTx = unsignedTransactions.get(shortTxHash)
+        if (unsignedTx == null) {
+            logger.warn { "No tx starting with hash $shortTxHash was found in collection of unsigned transactions" }
+            return
+        }
+        val tx = unsignedTx.tx
+        // Hash of transaction will be changed after signing. This is why we keep an "original" hash
+        val originalHash = tx.hashAsString
+        signCollector.getSignatures(originalHash).fold({ signatures ->
+            val enoughSignaturesCollected = signCollector.isEnoughSignaturesCollected(tx, signatures)
+            if (!enoughSignaturesCollected) {
+                logger.info { "Not enough signatures were collected for tx $originalHash" }
+                return
+            }
+            logger.info { "Tx $originalHash has enough signatures" }
+            signCollector.fillTxWithSignatures(tx, signatures)
+                .fold({
+                    peerGroup.broadcastTransaction(tx)
+                    unsignedTransactions.remove(shortTxHash)
+                }, { ex -> logger.error("Cannot complete tx $originalHash", ex) })
+
+
+        }, { ex -> logger.error("Cannot get signatures for tx $originalHash", ex) })
+    }
+
+    /**
+     * Logger
+     */
+    companion object : KLogging()
+}

--- a/btc-withdrawal/src/main/kotlin/withdrawal/btc/handler/WithdrawalTransferEventHandler.kt
+++ b/btc-withdrawal/src/main/kotlin/withdrawal/btc/handler/WithdrawalTransferEventHandler.kt
@@ -1,0 +1,101 @@
+package withdrawal.btc.handler
+
+import com.github.kittinunf.result.failure
+import com.github.kittinunf.result.map
+import iroha.protocol.Commands
+import mu.KLogging
+import org.bitcoinj.core.Transaction
+import org.bitcoinj.wallet.Wallet
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+import withdrawal.btc.config.BtcWithdrawalConfig
+import withdrawal.btc.provider.BtcWhiteListProvider
+import withdrawal.btc.transaction.SignCollector
+import withdrawal.btc.transaction.TransactionCreator
+import withdrawal.btc.transaction.UnsignedTransactions
+
+/*
+    Class that is used to handle withdrawal events
+ */
+@Component
+class WithdrawalTransferEventHandler(
+    @Autowired private val whiteListProvider: BtcWhiteListProvider,
+    @Autowired private val btcWithdrawalConfig: BtcWithdrawalConfig,
+    @Autowired private val transactionCreator: TransactionCreator,
+    @Autowired private val signCollector: SignCollector,
+    @Autowired private val unsignedTransactions: UnsignedTransactions
+) {
+    private val newBtcTransactionListeners = ArrayList<(tx: Transaction) -> Unit>()
+
+    /**
+     * Registers "new transaction was created" event listener
+     * Not thread safe. For testing purposes only.
+     * @param listener - function that will be called when new transaction is created
+     */
+    fun addNewBtcTransactionListener(listener: (tx: Transaction) -> Unit) {
+        newBtcTransactionListeners.add(listener)
+    }
+
+    /**
+     * Handles "transfer asset" command
+     * @param transferCommand - object with "transfer asset" data: source account, destination account, amount and etc
+     */
+    fun handleTransferCommand(wallet: Wallet, transferCommand: Commands.TransferAsset) {
+        if (transferCommand.destAccountId != btcWithdrawalConfig.withdrawalCredential.accountId) {
+            return
+        }
+        val destinationAddress = transferCommand.description
+        logger.info {
+            "Withdrawal event(" +
+                    "from:${transferCommand.srcAccountId} " +
+                    "to:$destinationAddress " +
+                    "amount:${transferCommand.amount})"
+        }
+        whiteListProvider.checkWithdrawalAddress(transferCommand.srcAccountId, destinationAddress)
+            .fold({ ableToWithdraw ->
+                if (ableToWithdraw) {
+                    withdraw(wallet, destinationAddress, transferCommand.amount.toLong())
+                } else {
+                    logger.warn { "Cannot withdraw to $destinationAddress, because it's not in ${transferCommand.srcAccountId} whitelist" }
+                }
+            }, { ex ->
+                logger.error("Cannot check ability to withdraw", ex)
+            })
+    }
+
+    /**
+     * Starts withdrawal process. Consists of the following steps:
+     * 1) Create transaction
+     * 2) Call all "on new transaction" listeners
+     * 3) Collect transaction input signatures using current node controlled private keys
+     * 4) Mark created transaction as unsigned
+     * @param wallet - current wallet. Used to obtain private keys
+     * @param destinationAddress - Bitcoin address to send money to
+     * @param amount - amount of SAT to send
+     * */
+    private fun withdraw(wallet: Wallet, destinationAddress: String, amount: Long) {
+        transactionCreator.createTransaction(
+            wallet,
+            amount,
+            destinationAddress,
+            btcWithdrawalConfig.bitcoin.confidenceLevel
+        ).map { transaction ->
+            newBtcTransactionListeners.forEach { listener ->
+                listener(transaction)
+            }
+            transaction
+        }.map { transaction ->
+            logger.info { "Tx to sign\n$transaction" }
+            signCollector.collectSignatures(transaction, wallet)
+            transaction
+        }.map { transaction ->
+            unsignedTransactions.markAsUnsigned(transaction)
+            logger.info { "Tx ${transaction.hashAsString} was added to collection of unsigned transactions" }
+        }.failure { ex -> logger.error("Cannot create withdrawal transaction", ex) }
+    }
+
+    /**
+     * Logger
+     */
+    companion object : KLogging()
+}

--- a/btc-withdrawal/src/main/kotlin/withdrawal/btc/provider/BtcWhiteListProvider.kt
+++ b/btc-withdrawal/src/main/kotlin/withdrawal/btc/provider/BtcWhiteListProvider.kt
@@ -1,4 +1,4 @@
-package withdrawal.btc
+package withdrawal.btc.provider
 
 import model.IrohaCredential
 import provider.WhiteListProvider

--- a/btc-withdrawal/src/main/kotlin/withdrawal/btc/transaction/TimedTx.kt
+++ b/btc-withdrawal/src/main/kotlin/withdrawal/btc/transaction/TimedTx.kt
@@ -1,4 +1,4 @@
-package withdrawal.btc
+package withdrawal.btc.transaction
 
 import org.bitcoinj.core.Transaction
 

--- a/btc-withdrawal/src/main/kotlin/withdrawal/btc/transaction/TransactionCreator.kt
+++ b/btc-withdrawal/src/main/kotlin/withdrawal/btc/transaction/TransactionCreator.kt
@@ -1,4 +1,4 @@
-package withdrawal.transaction
+package withdrawal.btc.transaction
 
 import com.github.kittinunf.result.Result
 import com.github.kittinunf.result.flatMap

--- a/btc-withdrawal/src/main/kotlin/withdrawal/btc/transaction/TransactionHelper.kt
+++ b/btc-withdrawal/src/main/kotlin/withdrawal/btc/transaction/TransactionHelper.kt
@@ -1,4 +1,4 @@
-package withdrawal.transaction
+package withdrawal.btc.transaction
 
 import com.github.kittinunf.result.Result
 import com.github.kittinunf.result.map

--- a/btc-withdrawal/src/main/kotlin/withdrawal/btc/transaction/UnsignedTransactions.kt
+++ b/btc-withdrawal/src/main/kotlin/withdrawal/btc/transaction/UnsignedTransactions.kt
@@ -1,0 +1,47 @@
+package withdrawal.btc.transaction
+
+import org.bitcoinj.core.Transaction
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+import java.util.concurrent.ConcurrentHashMap
+
+/*
+    Class that is used to store unsigned transactions
+ */
+
+@Component
+class UnsignedTransactions(
+    @Autowired private val signCollector: SignCollector
+) {
+    private val unsignedTransactions = ConcurrentHashMap<String, TimedTx>()
+
+    /**
+     * Marks transaction as unsigned. Transaction will be added to [unsignedTransactions] collection under the hood
+     * @param transaction - transaction to mark as unsigned
+     */
+    fun markAsUnsigned(transaction: Transaction) {
+        unsignedTransactions[signCollector.shortTxHash(transaction)] = TimedTx.create(transaction)
+    }
+
+    /**
+     * Removes transaction from [unsignedTransactions]
+     * @param txHash - hash of transaction to be removed
+     */
+    fun remove(txHash: String) {
+        unsignedTransactions.remove(signCollector.shortTxHash(txHash))
+    }
+
+    /**
+     * Returns unsigned transaction by its hash
+     * @param txHash - hash of transaction
+     * @return unsigned transaction or null
+     */
+    fun get(txHash: String) = unsignedTransactions[signCollector.shortTxHash(txHash)]
+
+    /**
+     * Checks if transaction with given hash is in [unsignedTransactions] collection
+     * @param txHash - hash of transaction to be checked
+     * @return - true if transaction with [txHash] is present
+     */
+    fun isUnsigned(txHash: String) = unsignedTransactions.containsKey(signCollector.shortTxHash(txHash))
+}

--- a/btc-withdrawal/src/main/kotlin/withdrawal/btc/transaction/UnsignedTransactions.kt
+++ b/btc-withdrawal/src/main/kotlin/withdrawal/btc/transaction/UnsignedTransactions.kt
@@ -13,6 +13,7 @@ import java.util.concurrent.ConcurrentHashMap
 class UnsignedTransactions(
     @Autowired private val signCollector: SignCollector
 ) {
+    //TODO create rollback mechanism
     private val unsignedTransactions = ConcurrentHashMap<String, TimedTx>()
 
     /**


### PR DESCRIPTION
Now we can sign withdrawal transactions and send it to Bitcoin network. Also a little refactor was made:
1) Handler functions are moved from `BtcWithdrawalInitialization` to dedicated classes: `NewSignatureEventHandler` and `WithdrawalTransferEventHandler`
2) Package structure is fixed