### PR TITLE
Batched address generation

### DIFF
--- a/notary-integration-test/src/integration-test/kotlin/integration/btc/BtcWithdrawalIntegrationTest.kt
+++ b/notary-integration-test/src/integration-test/kotlin/integration/btc/BtcWithdrawalIntegrationTest.kt
@@ -120,7 +120,6 @@ class BtcWithdrawalIntegrationTest {
         //Recreate folder
         blockStorageFolder.mkdirs()
         integrationHelper.generateBtcBlocks()
-        //TODO make it faster
         integrationHelper.preGenBtcAddresses(btcWithdrawalConfig.bitcoin.walletPath, TOTAL_TESTS * 2)
             .failure { ex -> throw ex }
         btcWithdrawalInitialization.init()


### PR DESCRIPTION
Address pregeneration in tests takes too much time. We can make it a lot faster using batched transactions.