### PR TITLE
Watched bitcoin addresses

### DIFF
--- a/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/environment/BtcWithdrawalTestEnvironment.kt
+++ b/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/environment/BtcWithdrawalTestEnvironment.kt
@@ -106,7 +106,8 @@ class BtcWithdrawalTestEnvironment(private val integrationHelper: BtcIntegration
             btcNetworkConfigProvider,
             withdrawalTransferEventHandler,
             newSignatureEventHandler,
-            NewBtcClientRegistrationHandler(btcNetworkConfigProvider)
+            NewBtcClientRegistrationHandler(btcNetworkConfigProvider),
+            btcRegisteredAddressesProvider
         )
     }
 


### PR DESCRIPTION
### Description of the Change
There is a need to add previously registered addresses to wallet's watched addresses. Otherwise, some deposit and withdrawal events may be out of sync.
