### PR TITLE
Boot repackage was disabled

### DIFF
--- a/btc/build.gradle
+++ b/btc/build.gradle
@@ -11,6 +11,8 @@ buildscript {
 
 apply plugin: "kotlin-spring" // See https://kotlinlang.org/docs/reference/compiler-plugins.html#kotlin-spring-compiler-plugin
 apply plugin: 'org.springframework.boot'
+// TODO 'build' quickfix. better solution is to remove 'spring-boot' plugin from this project
+bootRepackage.enabled = false
 
 dependencies {
     compile project(":notary-commons")


### PR DESCRIPTION
### Description of the Change
Spring Boot plugin adds a task called `bootRepackage` that packages spring project into an executable jar file. `btc` is a library project with no main class, meaning that it cannot be executed directly. That's why we don't need this task in this project.