### PR TITLE
Ignoring failed Iroha account creation command

### DIFF
--- a/btc-withdrawal/src/main/kotlin/withdrawal/btc/transaction/SignCollector.kt
+++ b/btc-withdrawal/src/main/kotlin/withdrawal/btc/transaction/SignCollector.kt
@@ -1,7 +1,6 @@
 package withdrawal.btc.transaction
 
 import com.github.kittinunf.result.Result
-import com.github.kittinunf.result.failure
 import com.github.kittinunf.result.flatMap
 import com.github.kittinunf.result.map
 import com.squareup.moshi.Moshi
@@ -62,13 +61,13 @@ class SignCollector(
             logger.info { "Tx ${tx.hashAsString} signatures to add in Iroha $signedInputs" }
             val shortTxHash = shortTxHash(tx)
             val createAccountTx = IrohaConverterImpl().convert(createSignCollectionAccountTx(shortTxHash))
+            /**
+             * We create a dedicated account everytime a withdrawal transaction occurred.
+             * We need this account to store transaction signatures from all the nodes.
+             * Every node will try to create an account, but only one creation will be succeeded.
+             * So it's ok to fail the following Iroha command.
+             */
             signatureCollectorConsumer.sendAndCheck(createAccountTx)
-                .failure { ex ->
-                    throw IllegalStateException(
-                        "Cannot create signature storing account for tx ${tx.hashAsString}",
-                        ex
-                    )
-                }
             val setSignaturesTx = IrohaConverterImpl().convert(setSignatureDetailsTx(shortTxHash, signedInputs))
             signatureCollectorConsumer.sendAndCheck(setSignaturesTx)
         }.fold(

--- a/btc-withdrawal/src/main/kotlin/withdrawal/btc/transaction/SignCollector.kt
+++ b/btc-withdrawal/src/main/kotlin/withdrawal/btc/transaction/SignCollector.kt
@@ -62,10 +62,10 @@ class SignCollector(
             val shortTxHash = shortTxHash(tx)
             val createAccountTx = IrohaConverterImpl().convert(createSignCollectionAccountTx(shortTxHash))
             /**
-             * We create a dedicated account everytime a withdrawal transaction occurred.
+             * We create a dedicated account on every withdrawal event.
              * We need this account to store transaction signatures from all the nodes.
-             * Every node will try to create an account, but only one creation will be succeeded.
-             * So it's ok to fail the following Iroha command.
+             * Every node will try to create an account, but only one creation will succeed.
+             * The following Iroha command can fail.
              */
             signatureCollectorConsumer.sendAndCheck(createAccountTx)
             val setSignaturesTx = IrohaConverterImpl().convert(setSignatureDetailsTx(shortTxHash, signedInputs))


### PR DESCRIPTION
### Description of the Bug
Two nodes cannot perform a withdrawal transaction simultaneously, because every node will try to create "tx signature storage" account. Only one account creation command will be successfully committed. So we have to ignore account creation command exceptions.