### PR TITLE
Bitcoin multisig address safe time source

### DIFF
--- a/btc-address-generation/src/main/kotlin/generation/btc/init/BtcAddressGenerationInitialization.kt
+++ b/btc-address-generation/src/main/kotlin/generation/btc/init/BtcAddressGenerationInitialization.kt
@@ -95,9 +95,8 @@ class BtcAddressGenerationInitialization(
             btcAddressGenerationConfig.registrationAccount.accountId
         ).flatMap { details ->
             // Getting time
-            val time = details[ADDRESS_GENERATION_TIME_KEY]!!.toLong()
-            // Removing generation time. Only public keys remain
-            details.remove(ADDRESS_GENERATION_TIME_KEY)
+            val time = details.remove(ADDRESS_GENERATION_TIME_KEY)!!.toLong()
+            // Getting keys
             val notaryKeys = details.values
             btcPublicKeyProvider.checkAndCreateMultiSigAddress(notaryKeys, addressType, time)
         }

--- a/btc-address-generation/src/main/kotlin/generation/btc/init/BtcAddressGenerationInitialization.kt
+++ b/btc-address-generation/src/main/kotlin/generation/btc/init/BtcAddressGenerationInitialization.kt
@@ -14,9 +14,10 @@ import mu.KLogging
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
-import provider.btc.generation.BtcPublicKeyProvider
 import provider.btc.address.BtcAddressType
 import provider.btc.address.getAddressTypeByAccountId
+import provider.btc.generation.ADDRESS_GENERATION_TIME_KEY
+import provider.btc.generation.BtcPublicKeyProvider
 import sidechain.iroha.IrohaChainListener
 import sidechain.iroha.consumer.IrohaNetwork
 import sidechain.iroha.util.getAccountDetails
@@ -74,13 +75,15 @@ class BtcAddressGenerationInitialization(
     private fun isAddressGenerationTriggered(command: Commands.Command) =
         command.setAccountDetail.accountId == btcAddressGenerationConfig.pubKeyTriggerAccount
 
-    // Check if new key was added
+    // Checks if new key was added
     private fun isNewKey(command: Commands.Command) = command.setAccountDetail.accountId.endsWith("btcSession")
 
+    // Generates new key
     private fun onGenerateKey(sessionAccountName: String): Result<String, Exception> {
         return btcPublicKeyProvider.createKey(sessionAccountName)
     }
 
+    // Generates multisig address
     private fun onGenerateMultiSigAddress(
         sessionAccount: String,
         addressType: BtcAddressType
@@ -91,8 +94,12 @@ class BtcAddressGenerationInitialization(
             sessionAccount,
             btcAddressGenerationConfig.registrationAccount.accountId
         ).flatMap { details ->
+            // Getting time
+            val time = details[ADDRESS_GENERATION_TIME_KEY]!!.toLong()
+            // Removing generation time. Only public keys remain
+            details.remove(ADDRESS_GENERATION_TIME_KEY)
             val notaryKeys = details.values
-            btcPublicKeyProvider.checkAndCreateMultiSigAddress(notaryKeys, addressType)
+            btcPublicKeyProvider.checkAndCreateMultiSigAddress(notaryKeys, addressType, time)
         }
     }
 

--- a/btc-address-generation/src/main/kotlin/generation/btc/trigger/AddressGenerationTrigger.kt
+++ b/btc-address-generation/src/main/kotlin/generation/btc/trigger/AddressGenerationTrigger.kt
@@ -5,8 +5,8 @@ import com.github.kittinunf.result.flatMap
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 import provider.TriggerProvider
-import provider.btc.generation.BtcSessionProvider
 import provider.btc.address.BtcAddressType
+import provider.btc.generation.BtcSessionProvider
 
 /*
     Class that is used to start address generation process

--- a/btc-deposit/src/main/kotlin/notary/btc/init/BtcNotaryInitialization.kt
+++ b/btc-deposit/src/main/kotlin/notary/btc/init/BtcNotaryInitialization.kt
@@ -52,7 +52,6 @@ class BtcNotaryInitialization(
         logger.info { "Btc notary initialization" }
         //Enables short log format for Bitcoin events
         BriefLogFormatter.init()
-        logger.info { "Current wallet state $wallet" }
         addPeerConnectionStatusListener(peerGroup, ::notHealthy, ::cured)
         return irohaChainListener.getBlockObservable().map { irohaObservable ->
             newBtcClientRegistrationListener.listenToRegisteredClients(wallet, irohaObservable)

--- a/btc/src/main/kotlin/provider/btc/generation/BtcPublicKeyProvider.kt
+++ b/btc/src/main/kotlin/provider/btc/generation/BtcPublicKeyProvider.kt
@@ -19,6 +19,7 @@ import sidechain.iroha.consumer.IrohaConsumer
 import sidechain.iroha.util.ModelUtil
 import util.getRandomId
 import wallet.WalletFile
+import java.math.BigInteger
 
 /**
  *  Bitcoin keys provider
@@ -45,7 +46,7 @@ class BtcPublicKeyProvider(
     @Autowired private val btcNetworkConfigProvider: BtcNetworkConfigProvider
 ) {
     init {
-        logger.info { "BtcPublicKeyProvider was successfully initialized. Current wallet state:\n${walletFile.wallet}" }
+        logger.info { "BtcPublicKeyProvider was successfully initialized" }
     }
 
     /**
@@ -72,48 +73,56 @@ class BtcPublicKeyProvider(
      * Creates multisignature address if enough public keys are provided
      * @param notaryKeys - list of all notaries public keys
      * @param addressType - type of address to create
+     * @param generationTime - time of address generation. Used in Iroha multisig
      * @return Result of operation
      */
     fun checkAndCreateMultiSigAddress(
         notaryKeys: Collection<String>,
-        addressType: BtcAddressType
+        addressType: BtcAddressType,
+        generationTime: Long
     ): Result<Unit, Exception> {
         return Result.of {
             val peers = notaryPeerListProvider.getPeerList().size
             if (peers == 0) {
                 throw IllegalStateException("No peers to create btc multisignature address")
-            } else if (notaryKeys.size == peers && hasMyKey(notaryKeys)) {
-                val threshold = getSignThreshold(peers)
-                val msAddress = createMsAddress(notaryKeys, threshold)
-                if (!walletFile.wallet.addWatchedAddress(msAddress)) {
-                    throw IllegalStateException("BTC address $msAddress was not added to wallet")
-                }
-                logger.info { "Address $msAddress was added to wallet. Current wallet state:\n${walletFile.wallet}" }
-
-                val (addressInfo, storageAccount) = when (addressType) {
-                    BtcAddressType.CHANGE -> {
-                        logger.info { "Creating change address" }
-                        Pair(
-                            AddressInfo.createChangeAddressInfo(ArrayList<String>(notaryKeys)),
-                            changeAddressStorageAccount
-                        )
-                    }
-                    BtcAddressType.FREE -> {
-                        logger.info { "Creating free address" }
-                        Pair(AddressInfo.createFreeAddressInfo(ArrayList<String>(notaryKeys)), notaryAccount)
-                    }
-                }
-                ModelUtil.setAccountDetail(
-                    multiSigConsumer,
-                    storageAccount,
-                    msAddress.toBase58(),
-                    addressInfo.toJson()
-                ).fold({
-                    //TODO this save will probably corrupt the wallet file
-                    walletFile.save()
-                    logger.info { "New BTC ${addressType.title} address $msAddress was created " }
-                }, { ex -> throw ex })
+            } else if (notaryKeys.size != peers) {
+                logger.info { "Not enough keys are collected to generate a multisig address(${notaryKeys.size} out of ${peers})" }
+                return@of
+            } else if (!hasMyKey(notaryKeys)) {
+                logger.info { "Cannot be involved in address generation. No access to $notaryKeys." }
+                return@of
             }
+            val threshold = getSignThreshold(peers)
+            val msAddress = createMsAddress(notaryKeys, threshold)
+            if (!walletFile.wallet.addWatchedAddress(msAddress)) {
+                throw IllegalStateException("BTC address $msAddress was not added to wallet")
+            }
+            logger.info { "Address $msAddress was added to wallet." }
+
+            val (addressInfo, storageAccount) = when (addressType) {
+                BtcAddressType.CHANGE -> {
+                    logger.info { "Creating change address" }
+                    Pair(
+                        AddressInfo.createChangeAddressInfo(ArrayList<String>(notaryKeys)),
+                        changeAddressStorageAccount
+                    )
+                }
+                BtcAddressType.FREE -> {
+                    logger.info { "Creating free address" }
+                    Pair(AddressInfo.createFreeAddressInfo(ArrayList<String>(notaryKeys)), notaryAccount)
+                }
+            }
+            ModelUtil.setAccountDetail(
+                multiSigConsumer,
+                storageAccount,
+                msAddress.toBase58(),
+                addressInfo.toJson(),
+                BigInteger.valueOf(generationTime)
+            ).fold({
+                //TODO this save will probably corrupt the wallet file
+                walletFile.save()
+                logger.info { "New BTC ${addressType.title} address $msAddress was created " }
+            }, { ex -> throw ex })
         }
     }
 

--- a/btc/src/main/kotlin/provider/btc/generation/BtcPublicKeyProvider.kt
+++ b/btc/src/main/kotlin/provider/btc/generation/BtcPublicKeyProvider.kt
@@ -86,7 +86,7 @@ class BtcPublicKeyProvider(
             if (peers == 0) {
                 throw IllegalStateException("No peers to create btc multisignature address")
             } else if (notaryKeys.size != peers) {
-                logger.info { "Not enough keys are collected to generate a multisig address(${notaryKeys.size} out of ${peers})" }
+                logger.info { "Not enough keys are collected to generate a multisig address(${notaryKeys.size} out of $peers)" }
                 return@of
             } else if (!hasMyKey(notaryKeys)) {
                 logger.info { "Cannot be involved in address generation. No access to $notaryKeys." }
@@ -119,7 +119,6 @@ class BtcPublicKeyProvider(
                 addressInfo.toJson(),
                 BigInteger.valueOf(generationTime)
             ).fold({
-                //TODO this save will probably corrupt the wallet file
                 walletFile.save()
                 logger.info { "New BTC ${addressType.title} address $msAddress was created " }
             }, { ex -> throw ex })

--- a/btc/src/main/kotlin/provider/btc/generation/BtcSessionProvider.kt
+++ b/btc/src/main/kotlin/provider/btc/generation/BtcSessionProvider.kt
@@ -10,6 +10,9 @@ import sidechain.iroha.consumer.IrohaConverterImpl
 import sidechain.iroha.consumer.IrohaNetwork
 import sidechain.iroha.util.ModelUtil
 
+private const val BTC_SESSION_DOMAIN = "btcSession"
+const val ADDRESS_GENERATION_TIME_KEY = "addressGenerationTime"
+
 // Class for creating session accounts. Theses accounts are used to store BTC public keys.
 class BtcSessionProvider(
     private val credential: IrohaCredential,
@@ -30,16 +33,21 @@ class BtcSessionProvider(
                 ModelUtil.getCurrentTime(),
                 1,
                 arrayListOf(
+                    //Creating session account
                     IrohaCommand.CommandCreateAccount(
-                        sessionId, "btcSession", credential.keyPair.publicKey().hex()
+                        sessionId, BTC_SESSION_DOMAIN, credential.keyPair.publicKey().hex()
+                    ),
+                    //Setting address generation time
+                    IrohaCommand.CommandSetAccountDetail(
+                        "$sessionId@$BTC_SESSION_DOMAIN",
+                        ADDRESS_GENERATION_TIME_KEY,
+                        System.currentTimeMillis().toString()
                     )
                 )
             )
         }.flatMap { irohaTx ->
             val utx = IrohaConverterImpl().convert(irohaTx)
             irohaConsumer.sendAndCheck(utx)
-
         }
     }
-
 }

--- a/notary-commons/src/main/kotlin/sidechain/iroha/util/ModelUtil.kt
+++ b/notary-commons/src/main/kotlin/sidechain/iroha/util/ModelUtil.kt
@@ -218,17 +218,19 @@ object ModelUtil {
      * @param accountId - account to set details
      * @param key - key of detail
      * @param value - value of detail
+     * @param createdTime - time of tx creation. Current time by default
      * @return hex representation of transaction hash
      */
     fun setAccountDetail(
         irohaConsumer: IrohaConsumer,
         accountId: String,
         key: String,
-        value: String
+        value: String,
+        createdTime: BigInteger = getCurrentTime()
     ): Result<String, Exception> {
         val tx = ModelTransactionBuilder()
             .creatorAccountId(irohaConsumer.creator)
-            .createdTime(getCurrentTime())
+            .createdTime(createdTime)
             .setAccountDetail(accountId, key, value)
             .build()
         return irohaConsumer.sendAndCheck(tx)

--- a/notary-commons/src/main/kotlin/sidechain/iroha/util/RequestHelper.kt
+++ b/notary-commons/src/main/kotlin/sidechain/iroha/util/RequestHelper.kt
@@ -143,16 +143,16 @@ fun getAccountDetails(
     irohaNetwork: IrohaNetwork,
     acc: String,
     detailSetterAccount: String
-): Result<Map<String, String>, Exception> {
+): Result<MutableMap<String, String>, Exception> {
     return getAccountData(
         credential,
         irohaNetwork,
         acc
     ).map { json ->
         if (json.map[detailSetterAccount] == null)
-            mapOf()
+            mutableMapOf()
         else
-            json.map[detailSetterAccount] as Map<String, String>
+            json.map[detailSetterAccount] as MutableMap<String, String>
     }
 }
 


### PR DESCRIPTION
### Description of the Bug
We use Iroha multisig transactions to create Bitcoin addresses. A previous source of time was a node time, meaning that multisig will never be succeeded because it will have different hash value on different nodes. Now we set time at caller level before address generation process starts. Those who starts address generation process also sets a time for a current address generation session. This time will be used by multiple nodes.