### PR TITLE
Kill deposit if Iroha is not functioning

### DIFF
--- a/btc-deposit/src/main/kotlin/notary/btc/init/BtcNotaryInitialization.kt
+++ b/btc-deposit/src/main/kotlin/notary/btc/init/BtcNotaryInitialization.kt
@@ -58,8 +58,8 @@ class BtcNotaryInitialization(
                 wallet, irohaObservable
             ) {
                 // Kill deposit service if Iroha chain listener is not functioning
-                notHealthy()
                 close()
+                System.exit(1)
             }
             logger.info { "Registration service listener was successfully initialized" }
         }.flatMap {

--- a/btc-deposit/src/main/kotlin/notary/btc/init/BtcNotaryInitialization.kt
+++ b/btc-deposit/src/main/kotlin/notary/btc/init/BtcNotaryInitialization.kt
@@ -54,7 +54,13 @@ class BtcNotaryInitialization(
         BriefLogFormatter.init()
         addPeerConnectionStatusListener(peerGroup, ::notHealthy, ::cured)
         return irohaChainListener.getBlockObservable().map { irohaObservable ->
-            newBtcClientRegistrationListener.listenToRegisteredClients(wallet, irohaObservable)
+            newBtcClientRegistrationListener.listenToRegisteredClients(
+                wallet, irohaObservable
+            ) {
+                // Kill deposit service if Iroha chain listener is not functioning
+                notHealthy()
+                close()
+            }
             logger.info { "Registration service listener was successfully initialized" }
         }.flatMap {
             btcRegisteredAddressesProvider.getRegisteredAddresses()

--- a/btc/src/main/kotlin/listener/btc/NewBtcClientRegistrationListener.kt
+++ b/btc/src/main/kotlin/listener/btc/NewBtcClientRegistrationListener.kt
@@ -21,7 +21,11 @@ class NewBtcClientRegistrationListener(
     /**
      * Listens to newly registered Bitcoin addresses and adds addresses to current wallet object
      */
-    fun listenToRegisteredClients(wallet: Wallet, irohaObservable: Observable<BlockOuterClass.Block>) {
+    fun listenToRegisteredClients(
+        wallet: Wallet,
+        irohaObservable: Observable<BlockOuterClass.Block>,
+        onChainListenerFail: () -> Unit
+    ) {
         irohaObservable.subscribeOn(Schedulers.from(Executors.newSingleThreadExecutor()))
             .subscribe({ block ->
                 getSetDetailCommands(block).forEach { command ->
@@ -29,6 +33,7 @@ class NewBtcClientRegistrationListener(
                 }
             }, { ex ->
                 logger.error("Error on subscribe", ex)
+                onChainListenerFail()
             })
     }
 


### PR DESCRIPTION
### Description of the Change
We have to kill deposit service if Iroha is not functioning.  Otherwise, deposit events will not be handled by Iroha. This situation may cause money loss.