### PR TITLE
Automatic BTC addresses generation

### DIFF
--- a/btc-address-generation/src/main/kotlin/generation/btc/config/BtcAddressGenerationConfig.kt
+++ b/btc-address-generation/src/main/kotlin/generation/btc/config/BtcAddressGenerationConfig.kt
@@ -35,4 +35,7 @@ interface BtcAddressGenerationConfig {
 
     //Port of health check service
     val healthCheckPort: Int
+
+    //Minimum number of free addresses to keep in Iroha
+    val threshold: Int
 }

--- a/btc-address-generation/src/main/kotlin/generation/btc/main.kt
+++ b/btc-address-generation/src/main/kotlin/generation/btc/main.kt
@@ -14,7 +14,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.context.annotation.ComponentScan
 
 @SpringBootApplication
-@ComponentScan(basePackages = ["generation", "healthcheck", "provider.btc.generation", "provider.btc.network"])
+@ComponentScan(basePackages = ["generation", "healthcheck", "provider.btc.generation", "provider.btc.network", "generation.btc.trigger"])
 class BtcAddressGenerationApplication
 
 private val logger = KLogging().logger

--- a/btc-address-generation/src/main/kotlin/generation/btc/trigger/AddressGenerationTrigger.kt
+++ b/btc-address-generation/src/main/kotlin/generation/btc/trigger/AddressGenerationTrigger.kt
@@ -2,11 +2,19 @@ package generation.btc.trigger
 
 import com.github.kittinunf.result.Result
 import com.github.kittinunf.result.flatMap
+import com.github.kittinunf.result.map
+import mu.KLogging
+import notary.IrohaOrderedBatch
+import notary.IrohaTransaction
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
 import provider.TriggerProvider
 import provider.btc.address.BtcAddressType
+import provider.btc.address.BtcFreeAddressesProvider
 import provider.btc.generation.BtcSessionProvider
+import sidechain.iroha.consumer.IrohaConsumer
+import sidechain.iroha.consumer.IrohaConverter
 
 /*
     Class that is used to start address generation process
@@ -14,19 +22,55 @@ import provider.btc.generation.BtcSessionProvider
 @Component
 class AddressGenerationTrigger(
     @Autowired private val btcSessionProvider: BtcSessionProvider,
-    @Autowired private val btcAddressGenerationTriggerProvider: TriggerProvider
+    @Autowired private val btcAddressGenerationTriggerProvider: TriggerProvider,
+    @Autowired private val btcFreeAddressesProvider: BtcFreeAddressesProvider,
+    @Qualifier("addressGenerationConsumer")
+    @Autowired private val addressGenerationConsumer: IrohaConsumer
 ) {
     /**
      * Starts address generation process
      * @param addressType - type of address to generate
+     * @param addressesToGenerate - number of addresses to generate. 1 by default.
      */
-    fun startAddressGeneration(addressType: BtcAddressType): Result<Unit, Exception> {
-        val sessionAccountName = addressType.createSessionAccountName()
-        return btcSessionProvider.createPubKeyCreationSession(sessionAccountName)
-            .flatMap {
-                btcAddressGenerationTriggerProvider.trigger(
+    fun startAddressGeneration(
+        addressType: BtcAddressType,
+        addressesToGenerate: Int = 1
+    ): Result<Unit, Exception> {
+        val txList = ArrayList<IrohaTransaction>()
+        for (addresses in 1..addressesToGenerate) {
+            val sessionAccountName = addressType.createSessionAccountName()
+            txList.add(btcSessionProvider.createPubKeyCreationSessionTx(sessionAccountName))
+            txList.add(
+                btcAddressGenerationTriggerProvider.triggerTx(
                     sessionAccountName
                 )
-            }
+            )
+        }
+        val utx = IrohaConverter.convert(IrohaOrderedBatch(txList))
+        return addressGenerationConsumer.send(utx)
+            .map { Unit }
     }
+
+    /**
+     * Starts free address generation process, if there is a need to generate.
+     * Addresses will be generated if there is not enough free addresses in Iroha.
+     * @param addressesThreshold - minimum number of free addresses to keep in Iroha
+     */
+    fun startFreeAddressGenerationIfNeeded(addressesThreshold: Int): Result<Unit, Exception> {
+        return btcFreeAddressesProvider.getFreeAddresses().flatMap { freeAddresses ->
+            if (freeAddresses.size < addressesThreshold) {
+                val addressesToGenerate = addressesThreshold - freeAddresses.size
+                logger.info { "Generating $addressesToGenerate addresses" }
+                startAddressGeneration(BtcAddressType.FREE, addressesToGenerate)
+            } else {
+                logger.info { "No need to generate addresses" }
+                Result.of { Unit }
+            }
+        }
+    }
+
+    /**
+     * Logger
+     */
+    companion object : KLogging()
 }

--- a/btc-address-generation/src/main/kotlin/generation/btc/trigger/BtcAddressGenerationTriggerAppConfiguration.kt
+++ b/btc-address-generation/src/main/kotlin/generation/btc/trigger/BtcAddressGenerationTriggerAppConfiguration.kt
@@ -3,11 +3,17 @@ package generation.btc.trigger
 import config.loadConfigs
 import generation.btc.config.BtcAddressGenerationConfig
 import jp.co.soramitsu.iroha.java.IrohaAPI
+import jp.co.soramitsu.iroha.java.QueryAPI
 import model.IrohaCredential
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import provider.TriggerProvider
+import provider.btc.address.BtcAddressesProvider
+import provider.btc.address.BtcFreeAddressesProvider
+import provider.btc.address.BtcRegisteredAddressesProvider
 import provider.btc.generation.BtcSessionProvider
+
+import sidechain.iroha.consumer.IrohaConsumerImpl
 import sidechain.iroha.util.ModelUtil
 
 val btcAddressGenerationTriggerConfig =
@@ -39,10 +45,42 @@ class BtcAddressGenerationTriggerAppConfiguration {
         )
 
     @Bean
+    fun registrationQueryAPI() = QueryAPI(triggerIrohaAPI(), registrationCredential.accountId, registrationKeyPair)
+
+    @Bean
+    fun addressGenerationConsumer() = IrohaConsumerImpl(registrationCredential, triggerIrohaAPI())
+
+    @Bean
     fun btcSessionProvider() =
         BtcSessionProvider(registrationCredential, triggerIrohaAPI())
 
     @Bean
     fun triggerProvider() =
-        TriggerProvider(registrationCredential, triggerIrohaAPI(), btcAddressGenerationTriggerConfig.pubKeyTriggerAccount)
+        TriggerProvider(
+            registrationCredential,
+            triggerIrohaAPI(),
+            btcAddressGenerationTriggerConfig.pubKeyTriggerAccount
+        )
+
+    @Bean
+    fun btcAddressesProvider(): BtcAddressesProvider {
+        return BtcAddressesProvider(
+            registrationQueryAPI(),
+            btcAddressGenerationTriggerConfig.mstRegistrationAccount.accountId,
+            btcAddressGenerationTriggerConfig.notaryAccount
+        )
+    }
+
+    @Bean
+    fun btcRegisteredAddressesProvider(): BtcRegisteredAddressesProvider {
+        return BtcRegisteredAddressesProvider(
+            registrationQueryAPI(),
+            registrationCredential.accountId,
+            btcAddressGenerationTriggerConfig.notaryAccount
+        )
+    }
+
+    @Bean
+    fun btcFreeAddressesProvider() =
+        BtcFreeAddressesProvider(btcAddressesProvider(), btcRegisteredAddressesProvider())
 }

--- a/btc/src/main/kotlin/provider/btc/account/IrohaBtcAccountCreator.kt
+++ b/btc/src/main/kotlin/provider/btc/account/IrohaBtcAccountCreator.kt
@@ -7,6 +7,7 @@ import sidechain.iroha.CLIENT_DOMAIN
 import sidechain.iroha.consumer.IrohaConsumer
 
 const val BTC_WHITE_LIST_KEY = "btc_whitelist"
+const val BTC_CURRENCY_NAME_KEY = "bitcoin"
 
 /*
     Class that is used to create Bitcoin accounts in Iroha
@@ -15,7 +16,7 @@ class IrohaBtcAccountCreator(
     irohaConsumer: IrohaConsumer,
     notaryIrohaAccount: String
 ) {
-    private val irohaAccountCreator = IrohaAccountCreator(irohaConsumer, notaryIrohaAccount, "bitcoin")
+    private val irohaAccountCreator = IrohaAccountCreator(irohaConsumer, notaryIrohaAccount, BTC_CURRENCY_NAME_KEY)
 
     /**
      * Creates new Bitcoin account to Iroha with given address

--- a/btc/src/main/kotlin/provider/btc/address/BtcFreeAddressesProvider.kt
+++ b/btc/src/main/kotlin/provider/btc/address/BtcFreeAddressesProvider.kt
@@ -1,0 +1,27 @@
+package provider.btc.address
+
+import com.github.kittinunf.result.Result
+import com.github.kittinunf.result.fanout
+import com.github.kittinunf.result.map
+
+// Class that used to fetch free addresses(addresses that might be taken by clients)
+class BtcFreeAddressesProvider(
+    private val btcAddressesProvider: BtcAddressesProvider,
+    private val btcRegisteredAddressesProvider: BtcRegisteredAddressesProvider
+) {
+
+    /**
+     * Returns list of free(not taken by clients) addresses
+     */
+    fun getFreeAddresses(): Result<List<BtcAddress>, Exception> {
+        return btcAddressesProvider.getAddresses()
+            .fanout { btcRegisteredAddressesProvider.getRegisteredAddresses() }
+            .map { (allAddresses, registeredAddresses) ->
+                val freeAddresses =
+                    allAddresses.filter { address ->
+                        !registeredAddresses.any { registeredAddress -> registeredAddress.address == address.address }
+                    }
+                freeAddresses
+            }
+    }
+}

--- a/btc/src/main/kotlin/provider/btc/generation/BtcSessionProvider.kt
+++ b/btc/src/main/kotlin/provider/btc/generation/BtcSessionProvider.kt
@@ -29,26 +29,36 @@ class BtcSessionProvider(
      */
     fun createPubKeyCreationSession(sessionId: String): Result<String, Exception> {
         return Result.of {
-            IrohaTransaction(
-                credential.accountId,
-                ModelUtil.getCurrentTime(),
-                1,
-                arrayListOf(
-                    //Creating session account
-                    IrohaCommand.CommandCreateAccount(
-                        sessionId, BTC_SESSION_DOMAIN, String.hex(credential.keyPair.public.encoded)
-                    ),
-                    //Setting address generation time
-                    IrohaCommand.CommandSetAccountDetail(
-                        "$sessionId@$BTC_SESSION_DOMAIN",
-                        ADDRESS_GENERATION_TIME_KEY,
-                        System.currentTimeMillis().toString()
-                    )
-                )
-            )
+            createPubKeyCreationSessionTx(sessionId)
         }.flatMap { irohaTx ->
             val utx = IrohaConverter.convert(irohaTx)
             irohaConsumer.send(utx)
         }
+    }
+
+    /**
+     * Creates a transaction that may be used to create special session account for notaries public key storage
+     *
+     * @param sessionId session identifier aka session account name
+     * @return Iroha transaction full of session creation commands
+     */
+    fun createPubKeyCreationSessionTx(sessionId: String): IrohaTransaction {
+        return IrohaTransaction(
+            credential.accountId,
+            ModelUtil.getCurrentTime(),
+            1,
+            arrayListOf(
+                //Creating session account
+                IrohaCommand.CommandCreateAccount(
+                    sessionId, BTC_SESSION_DOMAIN, String.hex(credential.keyPair.public.encoded)
+                ),
+                //Setting address generation time
+                IrohaCommand.CommandSetAccountDetail(
+                    "$sessionId@$BTC_SESSION_DOMAIN",
+                    ADDRESS_GENERATION_TIME_KEY,
+                    System.currentTimeMillis().toString()
+                )
+            )
+        )
     }
 }

--- a/configs/btc/address_generation_local.properties
+++ b/configs/btc/address_generation_local.properties
@@ -5,6 +5,7 @@ btc-address-generation.notaryListStorageAccount=notaries@notary
 btc-address-generation.healthCheckPort=7071
 btc-address-generation.notaryListSetterAccount=notary@notary
 btc-address-generation.changeAddressesStorageAccount=btc_change_addresses@notary
+btc-address-generation.threshold=5
 # --------- Credentials ----------
 btc-address-generation.registrationAccount.accountId=btc_registration_service@notary
 btc-address-generation.registrationAccount.pubkeyPath=deploy/iroha/keys/btc_registration_service@notary.pub

--- a/configs/btc/address_generation_mainnet.properties
+++ b/configs/btc/address_generation_mainnet.properties
@@ -5,6 +5,7 @@ btc-address-generation.notaryListStorageAccount=notaries@notary
 btc-address-generation.healthCheckPort=7071
 btc-address-generation.notaryListSetterAccount=notary@notary
 btc-address-generation.changeAddressesStorageAccount=btc_change_addresses@notary
+btc-address-generation.threshold=5
 # --------- Credentials ----------
 btc-address-generation.registrationAccount.accountId=btc_registration_service@notary
 btc-address-generation.registrationAccount.pubkeyPath=deploy/iroha/keys/btc_registration_service@notary.pub

--- a/configs/btc/address_generation_testnet.properties
+++ b/configs/btc/address_generation_testnet.properties
@@ -5,6 +5,7 @@ btc-address-generation.notaryListStorageAccount=notaries@notary
 btc-address-generation.healthCheckPort=7071
 btc-address-generation.notaryListSetterAccount=notary@notary
 btc-address-generation.changeAddressesStorageAccount=btc_change_addresses@notary
+btc-address-generation.threshold=5
 # --------- Credentials ----------
 btc-address-generation.registrationAccount.accountId=btc_registration_service@notary
 btc-address-generation.registrationAccount.pubkeyPath=deploy/iroha/keys/btc_registration_service@notary.pub

--- a/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/BtcAddressGenerationIntegrationTest.kt
+++ b/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/BtcAddressGenerationIntegrationTest.kt
@@ -21,8 +21,7 @@ import provider.btc.address.BtcAddressType
 import provider.btc.generation.ADDRESS_GENERATION_TIME_KEY
 import java.io.File
 
-private const val WAIT_PREGEN_INIT_MILLIS = 10_000L
-const val WAIT_PREGEN_PROCESS_MILLIS = 15_000L
+const val WAIT_PREGEN_PROCESS_MILLIS = 20_000L
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class BtcAddressGenerationIntegrationTest {
@@ -51,7 +50,9 @@ class BtcAddressGenerationIntegrationTest {
         GlobalScope.launch {
             environment.btcAddressGenerationInitialization.init().failure { ex -> throw ex }
         }
-        Thread.sleep(WAIT_PREGEN_INIT_MILLIS)
+        // Wait for initial address generation
+        Thread.sleep(WAIT_PREGEN_PROCESS_MILLIS * environment.btcGenerationConfig.threshold)
+        environment.checkIfAddressesWereGeneratedAtInitialPhase()
     }
 
     /**

--- a/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/BtcWithdrawalIntegrationTest.kt
+++ b/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/BtcWithdrawalIntegrationTest.kt
@@ -20,8 +20,8 @@ import java.math.BigDecimal
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 
-const val WITHDRAWAL_WAIT_MILLIS = 17_500L
-private const val DEFAULT_FEE_RATE = 10
+const val WITHDRAWAL_WAIT_MILLIS = 20_000L
+const val DEFAULT_FEE_RATE = 10
 private const val TOTAL_TESTS = 14
 private const val FAILED_WITHDRAW_AMOUNT = 6666L
 private const val FAILED_BROADCAST_AMOUNT = 7777L

--- a/notary-btc-integration-test/src/main/kotlin/integration/helper/BtcConfigHelper.kt
+++ b/notary-btc-integration-test/src/main/kotlin/integration/helper/BtcConfigHelper.kt
@@ -1,7 +1,6 @@
 package integration.helper
 
 import config.BitcoinConfig
-import config.IrohaCredentialConfig
 import config.loadConfigs
 import generation.btc.config.BtcAddressGenerationConfig
 import notary.btc.config.BtcNotaryConfig
@@ -28,6 +27,7 @@ class BtcConfigHelper(
             ).get()
 
         return object : BtcAddressGenerationConfig {
+            override val threshold = 2
             override val changeAddressesStorageAccount = accountHelper.changeAddressesStorageAccount.accountId
             override val healthCheckPort = btcPkPreGenConfig.healthCheckPort
             override val notaryListStorageAccount = accountHelper.notaryListStorageAccount.accountId


### PR DESCRIPTION
### Description of the Change
Now BTC addresses can be generated automatically. There are two cases that may trigger this process:
1) Address generation process was started for the first time
2) New client was registered