### PR TITLE
fix mkdir build-logs in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,7 +78,7 @@ pipeline {
           jacoco execPattern: 'build/jacoco/test.exec', sourcePattern: '.'
         }
         cleanup {
-          sh "mkdir build-logs"
+          sh "mkdir -p build-logs"
           sh """
             while read -r LINE; do \
               docker logs \$(echo \$LINE | cut -d ' ' -f1) | gzip -6 > build-logs/\$(echo \$LINE | cut -d ' ' -f2).log.gz; \


### PR DESCRIPTION
<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * Jenkins builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->


### Description of the Change
Add -p option to mkdir to be able complete build-logs task even if directory exists.
See build log error:
```
+ mkdir build-logs
mkdir: cannot create directory ‘build-logs’: File exists
Terminated
script returned exit code 1
```

### Usage Examples or Tests *[optional]*

See https://jenkins.soramitsu.co.jp/blue/organizations/jenkins/d3%2Fd3-notary/detail/update_xor_token/4/pipeline/
