### PR TITLE
Bitcoin-cli in gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ Command line args > Environment variables > Properties file
 
 `gradle integrationTest` for integation tests
 
+## Testing Bitcoin
+`gradlew btcSendToAddress -Paddress=<address> -PamountBtc=<amount>` — sends `<amount>` BTC to `<address>` in Bitcoin regtest network
+
+`gradlew btcGenerateBlocks -Pblocks=<blocks>` — generates `<blocks>` in Bitcoin regtest network
 
 ## Troubleshooting
 

--- a/btc/build.gradle
+++ b/btc/build.gradle
@@ -13,7 +13,7 @@ apply plugin: "kotlin-spring" // See https://kotlinlang.org/docs/reference/compi
 
 dependencies {
     compile project(":notary-commons")
-    
+
     //bitcoin
     compile 'org.bitcoinj:bitcoinj-core:0.14.7'
     // https://mvnrepository.com/artifact/org.iq80.leveldb/leveldb
@@ -42,6 +42,53 @@ dependencies {
 
     // https://mvnrepository.com/artifact/commons-logging/commons-logging
     compile group: 'commons-logging', name: 'commons-logging', version: '1.2'
+
+    // https://mvnrepository.com/artifact/com.github.jleskovar/btc-rpc-client
+    compile group: 'com.github.jleskovar', name: 'btc-rpc-client', version: '1.1.0'
+
+}
+
+// Forms a list full of 'btcSendToAddress' task arguments
+def getBtcSendToAddressArgs() {
+    List<String> args = new ArrayList<>()
+    if (project.hasProperty("address")) {
+        args.add(project.property("address").toString())
+    }
+    if (project.hasProperty("amountBtc")) {
+        args.add(project.property("amountBtc").toString())
+    }
+    return args
+}
+
+// Forms a list full of 'btcGenerateBlocks' task arguments
+def getBtcGenerateBlocksArgs() {
+    List<String> args = new ArrayList<>()
+    if (project.hasProperty("blocks")) {
+        args.add(project.property("blocks").toString())
+    }
+    return args
+}
+
+/** Sends money to Bitcoin address
+ *
+ * Usage ./gradlew btcSendToAddress -Paddress=<address> -PamountBtc=<amountBtc>
+ *  */
+task btcSendToAddress(type: JavaExec) {
+    main = 'cli.BtcSendToAddressMain'
+    args getBtcSendToAddressArgs()
+    classpath = sourceSets.main.runtimeClasspath
+    setWorkingDir("$rootDir/")
+}
+
+/** Generates blocks in Bitcoin blockchain
+ *
+ * Usage ./gradlew btcGenerateBlocks -Pblocks=<blocks>
+ */
+task btcGenerateBlocks(type: JavaExec) {
+    main = 'cli.BtcGenerateBlocksMain'
+    args getBtcGenerateBlocksArgs()
+    classpath = sourceSets.main.runtimeClasspath
+    setWorkingDir("$rootDir/")
 }
 
 sonarqube {

--- a/btc/src/main/kotlin/cli/BtcNodeRpcConfig.kt
+++ b/btc/src/main/kotlin/cli/BtcNodeRpcConfig.kt
@@ -1,0 +1,12 @@
+package cli
+
+interface BtcNodeRpcConfig {
+    //RPC password
+    val password: String
+    //RPC user
+    val user: String
+    //Bitcoin node host name
+    val host: String
+    //Bitcoin node port
+    val port: Int
+}

--- a/btc/src/main/kotlin/cli/GenerateBlocks.kt
+++ b/btc/src/main/kotlin/cli/GenerateBlocks.kt
@@ -1,0 +1,45 @@
+@file:JvmName("BtcGenerateBlocksMain")
+
+package cli
+
+import com.github.jleskovar.btcrpc.BitcoinRpcClientFactory
+import com.github.kittinunf.result.Result
+import config.loadConfigs
+import mu.KLogging
+
+private val logger = KLogging().logger
+
+private val btcNodeRpcConfig =
+    loadConfigs("btc-node-rpc", BtcNodeRpcConfig::class.java, "/btc/node-rpc.properties").get()
+
+private val rpcClient = BitcoinRpcClientFactory.createClient(
+    user = btcNodeRpcConfig.user,
+    password = btcNodeRpcConfig.password,
+    host = btcNodeRpcConfig.host,
+    port = btcNodeRpcConfig.port,
+    secure = false
+)
+
+/**
+ * Generates blocks in Bitcoin blockchain
+ * @param args - array full of arguments. args[0] - number of blocks to generate
+ */
+fun main(args: Array<String>) {
+    val blocksToGenerate = args[0].toInt()
+    Result.of {
+        rpcClient.generate(blocksToGenerate)
+    }.fold({
+        logger.info { prettyLogMessage(blocksToGenerate) }
+    }, { ex ->
+        logger.error("Cannot generate blocks", ex)
+    })
+}
+
+// Returns pretty log message that contains information about how many blocks were generated
+private fun prettyLogMessage(blocksToGenerate: Int): String {
+    return if (blocksToGenerate > 1) {
+        "$blocksToGenerate blocks were successfully generated"
+    } else {
+        "$blocksToGenerate block was successfully generated"
+    }
+}

--- a/btc/src/main/kotlin/cli/SendToAddress.kt
+++ b/btc/src/main/kotlin/cli/SendToAddress.kt
@@ -1,0 +1,42 @@
+@file:JvmName("BtcSendToAddressMain")
+
+package cli
+
+import com.github.jleskovar.btcrpc.BitcoinRpcClientFactory
+import com.github.kittinunf.result.Result
+import com.github.kittinunf.result.map
+import config.loadConfigs
+import mu.KLogging
+import java.math.BigDecimal
+
+private const val CONFIRMATION_BLOCKS = 6
+private val logger = KLogging().logger
+
+private val btcNodeRpcConfig =
+    loadConfigs("btc-node-rpc", BtcNodeRpcConfig::class.java, "/btc/node-rpc.properties").get()
+
+private val rpcClient = BitcoinRpcClientFactory.createClient(
+    user = btcNodeRpcConfig.user,
+    password = btcNodeRpcConfig.password,
+    host = btcNodeRpcConfig.host,
+    port = btcNodeRpcConfig.port,
+    secure = false
+)
+
+/**
+ * Sends money to desired Bitcoin address
+ * @param args - array full of arguments. args[0] - address, args[1] - amount of BTC to send
+ */
+fun main(args: Array<String>) {
+    val address = args[0]
+    val btcAmount = args[1]
+    Result.of {
+        rpcClient.sendToAddress(address, BigDecimal(btcAmount))
+    }.map {
+        rpcClient.generate(CONFIRMATION_BLOCKS)
+    }.fold({
+        logger.info { "BTC $btcAmount was successfully sent to $address" }
+    }, { ex ->
+        logger.error("Cannot send money", ex)
+    })
+}

--- a/configs/btc/node-rpc_local.properties
+++ b/configs/btc/node-rpc_local.properties
@@ -1,0 +1,8 @@
+# RPC password
+btc-node-rpc.password=test
+# RPC user
+btc-node-rpc.user=test
+# Bitcoin node host name
+btc-node-rpc.host=d3-btc-node0
+# Bitcoin node port
+btc-node-rpc.port=8332

--- a/notary-btc-integration-test/build.gradle
+++ b/notary-btc-integration-test/build.gradle
@@ -8,10 +8,6 @@ buildscript {
         classpath "org.springframework.boot:spring-boot-gradle-plugin:$spring_boot_version"
     }
 }
-dependencies {
-    // https://mvnrepository.com/artifact/com.github.jleskovar/btc-rpc-client
-    compile group: 'com.github.jleskovar', name: 'btc-rpc-client', version: '1.1.0'
-}
 
 sourceSets {
     integrationTest {


### PR DESCRIPTION
### Description of the Change
Now we can send Bitcoins and generate blocks with no bitcoin-cli or bitcoind being involved. 
Usage:
1) Generate blocks `./gradlew btcGenerateBlocks -Pblocks=<blocks>` 
2) Send to address `./gradlew btcSendToAddress -Paddress=<address> -PamountBtc=<amountBtc>` (no need to generate 6 blocks after that)