### PR TITLE
Fixing IPJ listener bug

### DIFF
--- a/btc-address-generation/src/main/kotlin/generation/btc/init/BtcAddressGenerationInitialization.kt
+++ b/btc-address-generation/src/main/kotlin/generation/btc/init/BtcAddressGenerationInitialization.kt
@@ -25,7 +25,6 @@ import sidechain.iroha.CLIENT_DOMAIN
 import sidechain.iroha.IrohaChainListener
 import sidechain.iroha.util.getAccountDetails
 import sidechain.iroha.util.getSetDetailCommands
-import java.util.concurrent.Executors
 
 /*
    This class listens to special account to be triggered and starts generation process
@@ -56,7 +55,7 @@ class BtcAddressGenerationInitialization(
     }
 
     private fun initIrohaObservable(irohaObservable: Observable<BlockOuterClass.Block>) {
-        irohaObservable.subscribeOn(Schedulers.from(Executors.newSingleThreadExecutor())).subscribe({ block ->
+        irohaObservable.subscribeOn(Schedulers.single()).subscribe({ block ->
             getSetDetailCommands(block).forEach { command ->
                 if (isNewClientRegistered(command)) {
                     // generate new multisignature address if new client has been registered recently

--- a/btc-withdrawal/src/main/kotlin/withdrawal/btc/config/BtcWithdrawalAppConfiguration.kt
+++ b/btc-withdrawal/src/main/kotlin/withdrawal/btc/config/BtcWithdrawalAppConfiguration.kt
@@ -3,6 +3,7 @@ package withdrawal.btc.config
 import config.BitcoinConfig
 import config.loadConfigs
 import fee.BtcFeeRateService
+import io.grpc.ManagedChannelBuilder
 import jp.co.soramitsu.iroha.java.IrohaAPI
 import jp.co.soramitsu.iroha.java.QueryAPI
 import model.IrohaCredential
@@ -17,6 +18,7 @@ import withdrawal.btc.provider.BtcChangeAddressProvider
 import withdrawal.btc.provider.BtcWhiteListProvider
 import withdrawal.btc.statistics.WithdrawalStatistics
 import java.io.File
+import java.util.concurrent.Executors
 
 val withdrawalConfig =
     loadConfigs("btc-withdrawal", BtcWithdrawalConfig::class.java, "/btc/withdrawal.properties").get()
@@ -72,14 +74,26 @@ class BtcWithdrawalAppConfiguration {
     fun withdrawalConfig() = withdrawalConfig
 
     @Bean
-    fun withdrawalIrohaChainListener() = IrohaChainListener(
-        withdrawalConfig.iroha.hostname,
-        withdrawalConfig.iroha.port,
-        withdrawalCredential()
-    )
+    fun irohaAPI(): IrohaAPI {
+        val irohaAPI = IrohaAPI(withdrawalConfig.iroha.hostname, withdrawalConfig.iroha.port)
+        /**
+         * It's essential to handle blocks in this service one-by-one.
+         * This is why we explicitly set single threaded executor.
+         */
+        irohaAPI.setChannelForStreamingQueryStub(
+            ManagedChannelBuilder.forAddress(
+                withdrawalConfig.iroha.hostname,
+                withdrawalConfig.iroha.port
+            ).executor(Executors.newSingleThreadExecutor()).usePlaintext().build()
+        )
+        return irohaAPI
+    }
 
     @Bean
-    fun irohaAPI() = IrohaAPI(withdrawalConfig.iroha.hostname, withdrawalConfig.iroha.port)
+    fun withdrawalIrohaChainListener() = IrohaChainListener(
+        irohaAPI(),
+        withdrawalCredential()
+    )
 
     @Bean
     fun queryAPI() = QueryAPI(irohaAPI(), btcFeeRateCredential.accountId, btcFeeRateCredential.keyPair)

--- a/btc-withdrawal/src/main/kotlin/withdrawal/btc/init/BtcWithdrawalInitialization.kt
+++ b/btc-withdrawal/src/main/kotlin/withdrawal/btc/init/BtcWithdrawalInitialization.kt
@@ -30,7 +30,6 @@ import withdrawal.btc.handler.WithdrawalTransferEventHandler
 import withdrawal.btc.listener.BitcoinBlockChainFeeRateListener
 import withdrawal.btc.provider.BtcChangeAddressProvider
 import java.io.Closeable
-import java.util.concurrent.Executors
 
 /*
     Class that initiates listeners that will be used to handle Bitcoin withdrawal logic
@@ -94,7 +93,7 @@ class BtcWithdrawalInitialization(
         peerGroup: PeerGroup
     ): Result<Unit, Exception> {
         return irohaChainListener.getBlockObservable().map { irohaObservable ->
-            irohaObservable.subscribeOn(Schedulers.from(Executors.newSingleThreadExecutor()))
+            irohaObservable.subscribeOn(Schedulers.single())
                 .subscribe({ block ->
                     // Handle transfer commands
                     getTransferCommands(block).forEach { command ->

--- a/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/environment/BtcWithdrawalTestEnvironment.kt
+++ b/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/environment/BtcWithdrawalTestEnvironment.kt
@@ -5,6 +5,8 @@ import fee.BtcFeeRateService
 import handler.btc.NewBtcClientRegistrationHandler
 import helper.address.outPutToBase58Address
 import integration.helper.BtcIntegrationHelperUtil
+import io.grpc.ManagedChannelBuilder
+import jp.co.soramitsu.iroha.java.IrohaAPI
 import model.IrohaCredential
 import org.bitcoinj.core.Transaction
 import org.bitcoinj.core.TransactionOutput
@@ -27,6 +29,7 @@ import java.io.Closeable
 import java.io.File
 import java.net.InetAddress
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Executors
 
 /**
  * Bitcoin withdrawal service testing environment
@@ -37,6 +40,24 @@ class BtcWithdrawalTestEnvironment(private val integrationHelper: BtcIntegration
     val createdTransactions = ConcurrentHashMap<String, Pair<Long, Transaction>>()
 
     val btcWithdrawalConfig = integrationHelper.configHelper.createBtcWithdrawalConfig(testName)
+
+    private val irohaApi by lazy {
+        val irohaAPI = IrohaAPI(
+            btcWithdrawalConfig.iroha.hostname,
+            btcWithdrawalConfig.iroha.port
+        )
+        /**
+         * It's essential to handle blocks in this service one-by-one.
+         * This is why we explicitly set single threaded executor.
+         */
+        irohaAPI.setChannelForStreamingQueryStub(
+            ManagedChannelBuilder.forAddress(
+                btcWithdrawalConfig.iroha.hostname,
+                btcWithdrawalConfig.iroha.port
+            ).executor(Executors.newSingleThreadExecutor()).usePlaintext().build()
+        )
+        irohaAPI
+    }
 
     private val withdrawalKeypair = ModelUtil.loadKeypair(
         btcWithdrawalConfig.withdrawalCredential.pubkeyPath,
@@ -64,19 +85,18 @@ class BtcWithdrawalTestEnvironment(private val integrationHelper: BtcIntegration
 
     private val withdrawalIrohaConsumer = IrohaConsumerImpl(
         withdrawalCredential,
-        integrationHelper.irohaAPI
+        irohaApi
     )
 
     private val signaturesCollectorIrohaConsumer = IrohaConsumerImpl(
         signaturesCollectorCredential,
-        integrationHelper.irohaAPI
+        irohaApi
     )
 
-    private val btcFeeRateConsumer = IrohaConsumerImpl(btcFeeRateCredential, integrationHelper.irohaAPI)
+    private val btcFeeRateConsumer = IrohaConsumerImpl(btcFeeRateCredential, irohaApi)
 
     private val irohaChainListener = IrohaChainListener(
-        btcWithdrawalConfig.iroha.hostname,
-        btcWithdrawalConfig.iroha.port,
+        irohaApi,
         withdrawalCredential
     )
 
@@ -106,7 +126,7 @@ class BtcWithdrawalTestEnvironment(private val integrationHelper: BtcIntegration
         SignCollector(
             signaturesCollectorCredential,
             signaturesCollectorIrohaConsumer,
-            integrationHelper.irohaAPI,
+            irohaApi,
             transactionSigner
         )
 

--- a/notary-commons/src/main/kotlin/sidechain/iroha/IrohaChainListener.kt
+++ b/notary-commons/src/main/kotlin/sidechain/iroha/IrohaChainListener.kt
@@ -13,11 +13,16 @@ import sidechain.iroha.util.ModelUtil
  * Dummy implementation of [ChainListener] with effective dependencies
  */
 class IrohaChainListener(
-    irohaHost: String,
-    irohaPort: Int,
+    private val irohaAPI: IrohaAPI,
     private val credential: IrohaCredential
 ) : ChainListener<iroha.protocol.BlockOuterClass.Block> {
-    val irohaAPI = IrohaAPI(irohaHost, irohaPort)
+
+    constructor(
+        irohaHost: String,
+        irohaPort: Int,
+        credential: IrohaCredential
+    ) : this(IrohaAPI(irohaHost, irohaPort), credential)
+
 
     /**
      * Returns an observable that emits a new block every time it gets it from Iroha


### PR DESCRIPTION
### Description of the Change
Iroha chain listener handles blocks in grpc thread pool no matter what pool was set by developers. In some services, it's crucial to handle blocks in a single thread. This bug was fixed on IPJ side. We must fix it on our side.