### PR TITLE
Email notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,10 @@ hs_err_pid*
 /btc-withdrawal/gradle
 /btc-withdrawal/gradlew
 /btc-withdrawal/gradlew.bat
+/notifications/build
+/notifications/gradle
+/notifications/gradlew
+/notifications/gradlew.bat
 /d3testreport/gradle
 /d3testreport/gradlew
 /d3testreport/gradlew.bat
@@ -147,3 +151,7 @@ deploy/bitcoin/regtest/d3.wallet
 deploy/bitcoin/testnet/d3.wallet
 deploy/bitcoin/regtest/d3-test.wallet
 deploy/bitcoin/mainnet/
+
+# SMTP configs
+configs/smtp.properties
+

--- a/configs/notifications.properties
+++ b/configs/notifications.properties
@@ -1,0 +1,11 @@
+# SMTP config path. This file contains SMTP password. Don't let this file be tracked by VCS
+notifications.smtpConfigPath=smtp.properties
+# --------- Iroha ---------
+# Iroha peer hostname
+notifications.iroha.hostname=d3-iroha
+# Iroha peer port
+notifications.iroha.port=50051
+# --------- Credentials -------
+notifications.notaryCredential.accountId=notary@notary
+notifications.notaryCredential.pubkeyPath=deploy/iroha/keys/notary0@notary.pub
+notifications.notaryCredential.privkeyPath=deploy/iroha/keys/notary0@notary.priv

--- a/notary-commons/src/main/kotlin/config/Configs.kt
+++ b/notary-commons/src/main/kotlin/config/Configs.kt
@@ -106,6 +106,11 @@ fun <T : Any> loadConfigs(
     return Result.of { loadValidatedConfigs(prefix, type, filename, *validators) }
 }
 
+/**
+ * Returns default D3 config folder
+ */
+fun getConfigFolder() = System.getProperty("user.dir") + "/configs"
+
 private fun <T : Any> loadValidatedConfigs(
     prefix: String,
     type: Class<T>,
@@ -114,8 +119,7 @@ private fun <T : Any> loadValidatedConfigs(
 ): T {
     val profile = getProfile()
     val (file, extension) = filename.split(".")
-    val pwd = System.getProperty("user.dir")
-    val path = "$pwd/configs${file}_$profile.$extension"
+    val path = "${getConfigFolder()}${file}_$profile.$extension"
     logger.info { "Loading config from $path, prefix $prefix" }
     val config = loadRawConfigs(prefix, type, path)
     validators.forEach { rule -> rule.validate(config) }

--- a/notary-commons/src/main/kotlin/model/D3Client.kt
+++ b/notary-commons/src/main/kotlin/model/D3Client.kt
@@ -1,0 +1,30 @@
+package model
+
+const val D3_CLIENT_EMAIL_KEY = "email"
+const val D3_CLIENT_ENABLE_NOTIFICATIONS = "notifications"
+
+/**
+ * D3 client data class
+ */
+data class D3Client(
+    val accountId: String,
+    val email: String?,
+    val enableNotifications: Boolean
+) {
+    companion object {
+
+        /**
+         * Factory function that creates D3 client object using client account details
+         * @param name - client accountId
+         * @param details - account details taken from Iroha
+         * @return d3 client
+         */
+        fun create(name: String, details: Map<String, String>): D3Client {
+            val enableNotifications: Boolean
+            details[D3_CLIENT_ENABLE_NOTIFICATIONS].let { notificationSetting ->
+                enableNotifications = ("true" == notificationSetting)
+            }
+            return D3Client(name, details[D3_CLIENT_EMAIL_KEY], enableNotifications)
+        }
+    }
+}

--- a/notary-commons/src/main/kotlin/provider/D3ClientProvider.kt
+++ b/notary-commons/src/main/kotlin/provider/D3ClientProvider.kt
@@ -1,0 +1,27 @@
+package provider
+
+import com.github.kittinunf.result.Result
+import com.github.kittinunf.result.map
+import jp.co.soramitsu.iroha.java.QueryAPI
+import model.D3Client
+import sidechain.iroha.util.getAccountDetails
+
+/**
+ * Class that is used to get information about D3 clients
+ */
+class D3ClientProvider(private val notaryQueryAPI: QueryAPI) {
+
+    /**
+     * Returns D3 client by its id
+     * @param accountId - account id of client
+     * @return D3 client
+     */
+    fun getClient(accountId: String): Result<D3Client, Exception> {
+        // Assuming that client sets details himself
+        return getAccountDetails(notaryQueryAPI, accountId, accountId)
+            .map { accountDetails ->
+                D3Client.create(accountId, accountDetails)
+            }
+    }
+}
+

--- a/notary-commons/src/main/kotlin/sidechain/iroha/IrohaVals.kt
+++ b/notary-commons/src/main/kotlin/sidechain/iroha/IrohaVals.kt
@@ -1,4 +1,5 @@
 package sidechain.iroha
 
 const val CLIENT_DOMAIN = "d3"
+const val NOTARY_DOMAIN = "notary"
 const val BTC_SIGN_COLLECT_DOMAIN = "btcSignCollect"

--- a/notifications-integration-test/build.gradle
+++ b/notifications-integration-test/build.gradle
@@ -1,0 +1,53 @@
+buildscript {
+    repositories {
+        mavenCentral()
+        jcenter()
+    }
+}
+dependencies {
+    compile project(":notifications")
+    compile project(":notary-iroha-integration-test")
+    // unit tests
+    testCompile('org.junit.jupiter:junit-jupiter-api:5.2.0')
+    testRuntime('org.junit.jupiter:junit-jupiter-engine:5.2.0')
+}
+
+sourceSets {
+    integrationTest {
+        kotlin {
+            compileClasspath += main.output + test.output
+            runtimeClasspath += main.output + test.output
+            srcDirs += 'src/integration-test/kotlin'
+        }
+        resources {
+            srcDirs = ["src/integration-test/resources"]
+        }
+    }
+}
+
+configurations {
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestCompile.extendsFrom testCompile
+    integrationTestRuntime.extendsFrom testRuntime
+}
+
+task integrationTest(type: Test) {
+    group = LifecycleBasePlugin.VERIFICATION_GROUP
+    description = 'Runs integration tests.'
+
+    testClassesDirs = sourceSets.integrationTest.output.classesDirs
+    classpath = sourceSets.integrationTest.runtimeClasspath
+    setWorkingDir("$rootDir/")
+    // Enable JUnit5 tests
+    useJUnitPlatform {
+    }
+
+    mustRunAfter test
+}
+check.dependsOn integrationTest
+
+sonarqube {
+    properties {
+        property "sonar.projectKey", "notary:notifications-integration-test"
+    }
+}

--- a/notifications-integration-test/src/integration-test/kotlin/notifications/NotificationsIntegrationTest.kt
+++ b/notifications-integration-test/src/integration-test/kotlin/notifications/NotificationsIntegrationTest.kt
@@ -1,0 +1,235 @@
+package notifications
+
+import com.github.kittinunf.result.Result
+import com.github.kittinunf.result.failure
+import com.github.kittinunf.result.map
+import com.nhaarman.mockito_kotlin.*
+import integration.helper.IrohaIntegrationHelperUtil
+import model.D3_CLIENT_EMAIL_KEY
+import model.D3_CLIENT_ENABLE_NOTIFICATIONS
+import notifications.environment.NotificationsIntegrationTestEnvironment
+import notifications.service.D3_DEPOSIT_EMAIL_SUBJECT
+import notifications.service.D3_WITHDRAWAL_EMAIL_SUBJECT
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.fail
+import org.mockito.Matchers.anyString
+import sidechain.iroha.CLIENT_DOMAIN
+import sidechain.iroha.util.ModelUtil
+import java.math.BigDecimal
+
+const val BTC_ASSET = "btc#bitcoin"
+private const val TRANSFER_WAIT_TIME = 3_000L
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class NotificationsIntegrationTest {
+
+    private val integrationHelper = IrohaIntegrationHelperUtil()
+
+    private val environment = NotificationsIntegrationTestEnvironment(integrationHelper)
+
+    init {
+        // This amount is big enough for testing
+        val amount = BigDecimal(100)
+
+        // Creating 2 clients
+        integrationHelper.createAccount(environment.srcClientName, CLIENT_DOMAIN, environment.srcClientKeyPair.public)
+        integrationHelper.createAccount(environment.destClientName, CLIENT_DOMAIN, environment.destClientKeyPair.public)
+
+        // Setting src client email
+        ModelUtil.setAccountDetail(
+            environment.srcClientConsumer,
+            environment.srcClientId,
+            D3_CLIENT_EMAIL_KEY,
+            "user@d3.com"
+        ).failure { ex -> throw ex }
+
+        // Setting dest client email
+        ModelUtil.setAccountDetail(
+            environment.destClientConsumer,
+            environment.destClientId,
+            D3_CLIENT_EMAIL_KEY,
+            "user@d3.com"
+        ).failure { ex -> throw ex }
+
+        // Enriching notary account
+        integrationHelper.addIrohaAssetTo(
+            integrationHelper.accountHelper.notaryAccount.accountId,
+            BTC_ASSET,
+            amount
+        )
+
+        // Enriching src account
+        integrationHelper.addIrohaAssetTo(
+            environment.srcClientId,
+            BTC_ASSET,
+            amount
+        )
+
+        // Run notifications service
+        environment.notificationInitialization.init()
+    }
+
+    @BeforeEach
+    fun resetMocks() {
+        // We need reset() in order to clear sendMessage() calls counter
+        reset(environment.smtpService)
+        whenever(
+            environment.smtpService.sendMessage(
+                anyString(),
+                anyString(),
+                anyString(),
+                anyString()
+            )
+        ).thenReturn(Result.of { Unit })
+    }
+
+    /**
+     * Note: Iroha must be deployed to pass the test.
+     * @given D3 client with enabled email notifications and notary account
+     * @when notary sends money to D3 client
+     * @then D3 client is notified about deposit
+     */
+    @Test
+    fun testNotificationDeposit() {
+        val depositValue = BigDecimal(1)
+
+        ModelUtil.setAccountDetail(
+            environment.srcClientConsumer,
+            environment.srcClientId,
+            D3_CLIENT_ENABLE_NOTIFICATIONS,
+            "true"
+        ).map {
+            val notaryAccount = integrationHelper.accountHelper.notaryAccount
+            integrationHelper.transferAssetIrohaFromClient(
+                notaryAccount.accountId,
+                notaryAccount.keyPair,
+                notaryAccount.accountId,
+                environment.srcClientId,
+                BTC_ASSET,
+                "no description",
+                depositValue.toPlainString()
+            )
+        }.map {
+            Thread.sleep(TRANSFER_WAIT_TIME)
+            verify(environment.smtpService).sendMessage(
+                anyString(),
+                anyString(),
+                eq(D3_DEPOSIT_EMAIL_SUBJECT),
+                anyString()
+            )
+            Unit
+        }.failure { ex -> fail(ex) }
+    }
+
+    /**
+     * Note: Iroha must be deployed to pass the test.
+     * @given D3 client with enabled email notifications and notary account
+     * @when D3 client sends money to notary account
+     * @then D3 client is notified about withdrawal
+     */
+    @Test
+    fun testNotificationWithdrawal() {
+        val withdrawalValue = BigDecimal(1)
+
+        ModelUtil.setAccountDetail(
+            environment.srcClientConsumer,
+            environment.srcClientId,
+            D3_CLIENT_ENABLE_NOTIFICATIONS,
+            "true"
+        ).map {
+            val notaryAccount = integrationHelper.accountHelper.notaryAccount
+            integrationHelper.transferAssetIrohaFromClient(
+                environment.srcClientId,
+                environment.srcClientKeyPair,
+                environment.srcClientId,
+                notaryAccount.accountId,
+                BTC_ASSET,
+                "no description",
+                withdrawalValue.toPlainString()
+            )
+        }.map {
+            Thread.sleep(TRANSFER_WAIT_TIME)
+            verify(environment.smtpService).sendMessage(
+                anyString(),
+                anyString(),
+                eq(D3_WITHDRAWAL_EMAIL_SUBJECT),
+                anyString()
+            )
+            Unit
+        }.failure { ex -> fail(ex) }
+    }
+
+    /**
+     * Note: Iroha must be deployed to pass the test.
+     * @given 2 D3 clients with enabled email notifications
+     * @when 1st client sends money to 2nd
+     * @then None of clients are notified, since it's a simple transfer
+     */
+    @Test
+    fun testNotificationSimpleTransfer() {
+        val transferValue = BigDecimal(1)
+
+        ModelUtil.setAccountDetail(
+            environment.srcClientConsumer,
+            environment.srcClientId,
+            D3_CLIENT_ENABLE_NOTIFICATIONS,
+            "true"
+        ).map {
+            ModelUtil.setAccountDetail(
+                environment.destClientConsumer,
+                environment.destClientId,
+                D3_CLIENT_ENABLE_NOTIFICATIONS,
+                "true"
+            )
+        }.map {
+            integrationHelper.transferAssetIrohaFromClient(
+                environment.srcClientId,
+                environment.srcClientKeyPair,
+                environment.srcClientId,
+                environment.destClientId,
+                BTC_ASSET,
+                "no description",
+                transferValue.toPlainString()
+            )
+        }.map {
+            Thread.sleep(TRANSFER_WAIT_TIME)
+            verify(environment.smtpService, never()).sendMessage(anyString(), anyString(), anyString(), anyString())
+            Unit
+        }.failure { ex -> fail(ex) }
+    }
+
+    /**
+     * Note: Iroha must be deployed to pass the test.
+     * @given D3 client with disabled email notifications and notary account
+     * @when notary sends money to D3 client
+     * @then D3 client is not notified about deposit
+     */
+    @Test
+    fun testNotificationDepositNotEnabled() {
+        val depositValue = BigDecimal(1)
+
+        ModelUtil.setAccountDetail(
+            environment.srcClientConsumer,
+            environment.srcClientId,
+            D3_CLIENT_ENABLE_NOTIFICATIONS,
+            "false"
+        ).map {
+            val notaryAccount = integrationHelper.accountHelper.notaryAccount
+            integrationHelper.transferAssetIrohaFromClient(
+                notaryAccount.accountId,
+                notaryAccount.keyPair,
+                notaryAccount.accountId,
+                environment.srcClientId,
+                BTC_ASSET,
+                "no description",
+                depositValue.toPlainString()
+            )
+        }.map {
+            Thread.sleep(TRANSFER_WAIT_TIME)
+            verify(environment.smtpService, never()).sendMessage(anyString(), anyString(), anyString(), anyString())
+            Unit
+        }.failure { ex -> fail(ex) }
+    }
+}

--- a/notifications-integration-test/src/integration-test/kotlin/notifications/environment/NotificationsIntegrationTestEnvironment.kt
+++ b/notifications-integration-test/src/integration-test/kotlin/notifications/environment/NotificationsIntegrationTestEnvironment.kt
@@ -1,0 +1,58 @@
+package notifications.environment
+
+import com.nhaarman.mockito_kotlin.mock
+import integration.helper.IrohaIntegrationHelperUtil
+import integration.helper.NotificationsConfigHelper
+import jp.co.soramitsu.iroha.java.IrohaAPI
+import jp.co.soramitsu.iroha.java.QueryAPI
+import model.IrohaCredential
+import notifications.init.NotificationInitialization
+import notifications.service.EmailNotificationService
+import notifications.smtp.SMTPService
+import provider.D3ClientProvider
+import sidechain.iroha.CLIENT_DOMAIN
+import sidechain.iroha.IrohaChainListener
+import sidechain.iroha.consumer.IrohaConsumerImpl
+import sidechain.iroha.util.ModelUtil
+import util.getRandomString
+
+/**
+ * Notifications service testing environment
+ */
+class NotificationsIntegrationTestEnvironment(private val integrationHelper: IrohaIntegrationHelperUtil) {
+
+    private val notificationsConfigHelper = NotificationsConfigHelper(integrationHelper.accountHelper)
+
+    private val notificationsConfig = notificationsConfigHelper.createNotificationsConfig()
+
+    private val irohaAPI = IrohaAPI(notificationsConfig.iroha.hostname, notificationsConfig.iroha.port)
+
+    private val irohaChainListener = IrohaChainListener(irohaAPI, integrationHelper.accountHelper.notaryAccount)
+
+    private val notaryQueryAPI = QueryAPI(
+        irohaAPI,
+        integrationHelper.accountHelper.notaryAccount.accountId,
+        integrationHelper.accountHelper.notaryAccount.keyPair
+    )
+
+    private val d3ClientProvider = D3ClientProvider(notaryQueryAPI)
+
+    val smtpService = mock<SMTPService>()
+
+    private val notificationService = EmailNotificationService(smtpService, d3ClientProvider)
+
+    val notificationInitialization = NotificationInitialization(irohaChainListener, notificationService)
+
+    // Source account
+    val srcClientName = String.getRandomString(9)
+    val srcClientKeyPair = ModelUtil.generateKeypair()
+    val srcClientId = "$srcClientName@$CLIENT_DOMAIN"
+    val srcClientConsumer = IrohaConsumerImpl(IrohaCredential(srcClientId, srcClientKeyPair), irohaAPI)
+
+    // Destination account
+    val destClientName = String.getRandomString(9)
+    val destClientKeyPair = ModelUtil.generateKeypair()
+    val destClientId = "$destClientName@$CLIENT_DOMAIN"
+    val destClientConsumer = IrohaConsumerImpl(IrohaCredential(destClientId, destClientKeyPair), irohaAPI)
+
+}

--- a/notifications-integration-test/src/integration-test/resources/log4j.properties
+++ b/notifications-integration-test/src/integration-test/resources/log4j.properties
@@ -1,0 +1,4 @@
+log4j.rootLogger=INFO, X
+log4j.appender.X=org.apache.log4j.ConsoleAppender
+log4j.appender.X.layout=org.apache.log4j.PatternLayout
+log4j.appender.X.layout.ConversionPattern=[%d{dd.MM.yyyy HH:mm:ss,SSS}] notifications-integration-tests [%-5p] [%t] %m%n

--- a/notifications-integration-test/src/main/kotlin/integration/helper/NotificationsConfigHelper.kt
+++ b/notifications-integration-test/src/main/kotlin/integration/helper/NotificationsConfigHelper.kt
@@ -1,0 +1,17 @@
+package integration.helper
+
+import notifications.config.NotificationsConfig
+
+class NotificationsConfigHelper(private val accountHelper: IrohaAccountHelper) : IrohaConfigHelper() {
+
+    /**
+     * Creates notification services config
+     */
+    fun createNotificationsConfig(): NotificationsConfig {
+        return object : NotificationsConfig {
+            override val iroha = createIrohaConfig()
+            override val smtpConfigPath = "no matter. its not used in tests"
+            override val notaryCredential = accountHelper.createCredentialConfig(accountHelper.notaryAccount)
+        }
+    }
+}

--- a/notifications/build.gradle
+++ b/notifications/build.gradle
@@ -1,0 +1,32 @@
+buildscript {
+    repositories {
+        mavenCentral()
+        jcenter()
+    }
+}
+apply plugin: 'application'
+apply plugin: "kotlin-spring" // See https://kotlinlang.org/docs/reference/compiler-plugins.html#kotlin-spring-compiler-plugin
+mainClassName = "notifications.NotificationsMain"
+
+dependencies {
+    compile project(":notary-commons")
+
+    // https://mvnrepository.com/artifact/javax.mail/mail
+    compile group: 'javax.mail', name: 'mail', version: '1.4.7'
+
+    // https://mvnrepository.com/artifact/org.springframework/spring-context
+    compile group: 'org.springframework', name: 'spring-context', version: '5.1.4.RELEASE'
+
+}
+
+task runNotifications(type: JavaExec) {
+    main = 'notifications.NotificationsMain'
+    classpath = sourceSets.main.runtimeClasspath
+    setWorkingDir("$rootDir/")
+}
+
+sonarqube {
+    properties {
+        property "sonar.projectKey", "notary:notifications"
+    }
+}

--- a/notifications/src/main/kotlin/notifications/config/NotificationAppConfiguration.kt
+++ b/notifications/src/main/kotlin/notifications/config/NotificationAppConfiguration.kt
@@ -1,0 +1,60 @@
+package notifications.config
+
+import config.getConfigFolder
+import config.loadRawConfigs
+import io.grpc.ManagedChannelBuilder
+import jp.co.soramitsu.iroha.java.IrohaAPI
+import jp.co.soramitsu.iroha.java.QueryAPI
+import model.IrohaCredential
+import notifications.smtp.SMTPServiceImpl
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import provider.D3ClientProvider
+import sidechain.iroha.IrohaChainListener
+import sidechain.iroha.util.ModelUtil
+import java.io.File
+
+val notificationsConfig = loadRawConfigs(
+    "notifications", NotificationsConfig::class.java, getConfigFolder() + "/notifications.properties"
+)
+
+@Configuration
+class NotificationAppConfiguration {
+
+    private val notaryKeypair = ModelUtil.loadKeypair(
+        notificationsConfig.notaryCredential.pubkeyPath,
+        notificationsConfig.notaryCredential.privkeyPath
+    ).fold({ keypair -> keypair }, { ex -> throw ex })
+
+    private val notaryCredential = IrohaCredential(notificationsConfig.notaryCredential.accountId, notaryKeypair)
+
+    @Bean
+    fun irohaAPI(): IrohaAPI {
+        val irohaAPI = IrohaAPI(notificationsConfig.iroha.hostname, notificationsConfig.iroha.port)
+        irohaAPI.setChannelForStreamingQueryStub(
+            ManagedChannelBuilder.forAddress(
+                notificationsConfig.iroha.hostname, notificationsConfig.iroha.port
+            ).directExecutor().usePlaintext().build()
+        )
+        return irohaAPI
+    }
+
+    @Bean
+    fun notaryQueryAPI() = QueryAPI(irohaAPI(), notificationsConfig.notaryCredential.accountId, notaryKeypair)
+
+    @Bean
+    fun smtpService() =
+        SMTPServiceImpl(
+            loadRawConfigs(
+                "smtp",
+                SMTPConfig::class.java,
+                getConfigFolder() + File.separator + notificationsConfig.smtpConfigPath
+            )
+        )
+
+    @Bean
+    fun d3ClientProvider() = D3ClientProvider(notaryQueryAPI())
+
+    @Bean
+    fun irohaChainListener() = IrohaChainListener(irohaAPI(), notaryCredential)
+}

--- a/notifications/src/main/kotlin/notifications/config/NotificationsConfig.kt
+++ b/notifications/src/main/kotlin/notifications/config/NotificationsConfig.kt
@@ -1,0 +1,30 @@
+package notifications.config
+
+import config.IrohaConfig
+import config.IrohaCredentialConfig
+
+/**
+ * Configuration of notification service
+ */
+interface NotificationsConfig {
+    // Iroha configs
+    val iroha: IrohaConfig
+    // Path to file with SMTP configs
+    val smtpConfigPath: String
+    // Notary account credential. Used to listen to Iroha blocks
+    val notaryCredential: IrohaCredentialConfig
+}
+
+/**
+ * SMTP configuration
+ */
+interface SMTPConfig {
+    // SMTP host
+    val host: String
+    // SMTP port
+    val port: Int
+    // SMTP user accountId
+    val userName: String
+    // SMTP password
+    val password: String
+}

--- a/notifications/src/main/kotlin/notifications/init/NotificationInitialization.kt
+++ b/notifications/src/main/kotlin/notifications/init/NotificationInitialization.kt
@@ -1,0 +1,100 @@
+package notifications.init
+
+import com.github.kittinunf.result.failure
+import com.github.kittinunf.result.map
+import io.reactivex.schedulers.Schedulers
+import iroha.protocol.Commands
+import mu.KLogging
+import notifications.service.NotificationService
+import notifications.service.TransferNotifyEvent
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+import sidechain.iroha.IrohaChainListener
+import sidechain.iroha.NOTARY_DOMAIN
+import sidechain.iroha.util.getTransferCommands
+import java.math.BigDecimal
+import java.util.concurrent.Executors
+
+/**
+ * Notifications initialization service
+ */
+@Component
+class NotificationInitialization(
+    @Autowired private val irohaChainListener: IrohaChainListener,
+    @Autowired private val notificationService: NotificationService
+) {
+
+    /**
+     * Initiates notification service
+     * @param onIrohaChainFailure - function that will be called in case of Iroha failure
+     */
+    fun init(onIrohaChainFailure: () -> Unit) {
+        irohaChainListener.getBlockObservable().map { irohaObservable ->
+            irohaObservable
+                .subscribeOn(Schedulers.from(Executors.newSingleThreadExecutor()))
+                .subscribe({ block ->
+                    //Get transfer commands from block
+                    getTransferCommands(block).forEach { command ->
+                        val transferAsset = command.transferAsset
+                        // Notify deposit
+                        if (isDeposit(transferAsset)) {
+                            handleDepositNotification(transferAsset)
+                        }
+                        // Notify withdrawal
+                        else if (isWithdrawal(transferAsset)) {
+                            handleWithdrawalEventNotification(transferAsset)
+                        }
+                    }
+                }, { ex ->
+                    logger.error("Error on Iroha subscribe", ex)
+                    onIrohaChainFailure()
+                })
+        }
+    }
+
+    // Checks if deposit event
+    private fun isDeposit(transferAsset: Commands.TransferAsset): Boolean {
+        return transferAsset.srcAccountId.endsWith("@$NOTARY_DOMAIN")
+    }
+
+    // Handles deposit event notification
+    private fun handleDepositNotification(transferAsset: Commands.TransferAsset) {
+        notificationService.notifyDeposit(
+            TransferNotifyEvent(
+                transferAsset.destAccountId,
+                BigDecimal(transferAsset.amount),
+                transferAsset.assetId
+            )
+        ).failure { ex -> logger.error("Cannot notify deposit", ex) }
+    }
+
+    // Checks if withdrawal event
+    private fun isWithdrawal(transferAsset: Commands.TransferAsset): Boolean {
+        return transferAsset.destAccountId.endsWith("@$NOTARY_DOMAIN")
+    }
+
+    // Handles withdrawal event notification
+    private fun handleWithdrawalEventNotification(transferAsset: Commands.TransferAsset) {
+        notificationService.notifyWithdrawal(
+            TransferNotifyEvent(
+                transferAsset.srcAccountId,
+                BigDecimal(transferAsset.amount),
+                transferAsset.assetId
+            )
+        ).failure { ex -> logger.error("Cannot notify withdrawal", ex) }
+    }
+
+    /**
+     *  Initiates notification service.
+     *  This overloaded version does nothing on Iroha failure.
+     *  Good for testing purposes.
+     */
+    fun init() {
+        init {}
+    }
+
+    /**
+     * Logger
+     */
+    companion object : KLogging()
+}

--- a/notifications/src/main/kotlin/notifications/main.kt
+++ b/notifications/src/main/kotlin/notifications/main.kt
@@ -1,0 +1,30 @@
+@file:JvmName("NotificationsMain")
+
+package notifications
+
+import com.github.kittinunf.result.Result
+import com.github.kittinunf.result.failure
+import com.github.kittinunf.result.map
+import mu.KLogging
+import notifications.init.NotificationInitialization
+import org.springframework.context.annotation.AnnotationConfigApplicationContext
+import org.springframework.context.annotation.ComponentScan
+
+@ComponentScan(basePackages = ["notifications"])
+class NotificationApplication
+
+private val logger = KLogging().logger
+
+/*
+  Notification service entry point
+ */
+fun main(args: Array<String>) {
+    Result.of {
+        AnnotationConfigApplicationContext(NotificationApplication::class.java)
+    }.map { context ->
+        context.getBean(NotificationInitialization::class.java).init { System.exit(1) }
+    }.failure { ex ->
+        logger.error("Cannot start notification service", ex)
+        System.exit(1)
+    }
+}

--- a/notifications/src/main/kotlin/notifications/service/EmailNotificationService.kt
+++ b/notifications/src/main/kotlin/notifications/service/EmailNotificationService.kt
@@ -1,0 +1,66 @@
+package notifications.service
+
+import com.github.kittinunf.result.Result
+import com.github.kittinunf.result.flatMap
+import mu.KLogging
+import notifications.smtp.SMTPService
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+import provider.D3ClientProvider
+
+private const val NOTIFICATION_EMAIL = "noreply@d3.com"
+const val D3_WITHDRAWAL_EMAIL_SUBJECT = "D3 withdrawal"
+const val D3_DEPOSIT_EMAIL_SUBJECT = "D3 deposit"
+
+/**
+ * Service for email notifications
+ */
+@Component
+class EmailNotificationService(
+    @Autowired private val smtpService: SMTPService,
+    @Autowired private val d3ClientProvider: D3ClientProvider
+) : NotificationService {
+
+    override fun notifyDeposit(transferNotifyEvent: TransferNotifyEvent): Result<Unit, Exception> {
+        logger.info { "Notify deposit $transferNotifyEvent" }
+        val message =
+            "Hello ${transferNotifyEvent.accountId}. We are happy to notify that ${transferNotifyEvent.amount} ${transferNotifyEvent.assetName} has been deposited to your account."
+        return checkClientAndSendMessage(transferNotifyEvent.accountId, D3_DEPOSIT_EMAIL_SUBJECT, message)
+    }
+
+    override fun notifyWithdrawal(transferNotifyEvent: TransferNotifyEvent): Result<Unit, Exception> {
+        logger.info { "Notify withdrawal $transferNotifyEvent" }
+        val message =
+            "Hello ${transferNotifyEvent.accountId}. We are happy to notify that ${transferNotifyEvent.amount} ${transferNotifyEvent.assetName} has been withdrawn from your account."
+        return checkClientAndSendMessage(transferNotifyEvent.accountId, D3_WITHDRAWAL_EMAIL_SUBJECT, message)
+    }
+
+    /**
+     * Checks if client wants to be notified and sends message
+     * @param accountId - account id of client
+     * @param subject - subject of message
+     * @param message - message of notification
+     * @return result of operation
+     */
+    private fun checkClientAndSendMessage(
+        accountId: String,
+        subject: String,
+        message: String
+    ): Result<Unit, Exception> {
+        return d3ClientProvider.getClient(accountId).flatMap { d3Client ->
+            if (!d3Client.enableNotifications) {
+                logger.info { "Client ${d3Client.accountId} doesn't want to be notified" }
+                return@flatMap Result.of { Unit }
+            } else if (d3Client.email == null) {
+                logger.warn { "Client ${d3Client.accountId} wants to be notified, but no email was set" }
+                return@flatMap Result.of { Unit }
+            }
+            smtpService.sendMessage(NOTIFICATION_EMAIL, d3Client.email!!, subject, message)
+        }
+    }
+
+    /**
+     * Logger
+     */
+    companion object : KLogging()
+}

--- a/notifications/src/main/kotlin/notifications/service/EmailNotificationService.kt
+++ b/notifications/src/main/kotlin/notifications/service/EmailNotificationService.kt
@@ -24,14 +24,14 @@ class EmailNotificationService(
     override fun notifyDeposit(transferNotifyEvent: TransferNotifyEvent): Result<Unit, Exception> {
         logger.info { "Notify deposit $transferNotifyEvent" }
         val message =
-            "Hello ${transferNotifyEvent.accountId}. We are happy to notify that ${transferNotifyEvent.amount} ${transferNotifyEvent.assetName} has been deposited to your account."
+            "Dear client, deposit of ${transferNotifyEvent.amount} ${transferNotifyEvent.assetName} to your account ${transferNotifyEvent.accountId} is successful."
         return checkClientAndSendMessage(transferNotifyEvent.accountId, D3_DEPOSIT_EMAIL_SUBJECT, message)
     }
 
     override fun notifyWithdrawal(transferNotifyEvent: TransferNotifyEvent): Result<Unit, Exception> {
         logger.info { "Notify withdrawal $transferNotifyEvent" }
         val message =
-            "Hello ${transferNotifyEvent.accountId}. We are happy to notify that ${transferNotifyEvent.amount} ${transferNotifyEvent.assetName} has been withdrawn from your account."
+            "Dear client, withdrawal of ${transferNotifyEvent.amount} ${transferNotifyEvent.assetName} from your account ${transferNotifyEvent.accountId} is successful."
         return checkClientAndSendMessage(transferNotifyEvent.accountId, D3_WITHDRAWAL_EMAIL_SUBJECT, message)
     }
 

--- a/notifications/src/main/kotlin/notifications/service/NotificationService.kt
+++ b/notifications/src/main/kotlin/notifications/service/NotificationService.kt
@@ -1,0 +1,32 @@
+package notifications.service
+
+import com.github.kittinunf.result.Result
+import java.math.BigDecimal
+
+/**
+ * Notification service interface
+ */
+interface NotificationService {
+    /**
+     * Notifies client about deposit event
+     * @param transferNotifyEvent - transfer event
+     * @return result of operation
+     * */
+    fun notifyDeposit(transferNotifyEvent: TransferNotifyEvent): Result<Unit, Exception>
+
+    /**
+     * Notifies client about withdrawal event
+     * @param transferNotifyEvent - transfer event
+     * @return result of operation
+     * */
+    fun notifyWithdrawal(transferNotifyEvent: TransferNotifyEvent): Result<Unit, Exception>
+}
+
+/**
+ * Data class that holds transfer event data
+ *
+ * @param accountId - account id that will be notified
+ * @param amount - transfer amount
+ * @param assetName - name of asset
+ */
+data class TransferNotifyEvent(val accountId: String, val amount: BigDecimal, val assetName: String)

--- a/notifications/src/main/kotlin/notifications/smtp/SMTPService.kt
+++ b/notifications/src/main/kotlin/notifications/smtp/SMTPService.kt
@@ -1,0 +1,19 @@
+package notifications.smtp
+
+import com.github.kittinunf.result.Result
+
+/**
+ * Interface of service that is used to send email messages using SMTP
+ */
+interface SMTPService {
+
+    /**
+     * Sends email message
+     * @param from - email of sender
+     * @param to - destination email
+     * @param subject - subject of email message
+     * @param message - message itself
+     * @return result of operation
+     */
+    fun sendMessage(from: String, to: String, subject: String, message: String): Result<Unit, Exception>
+}

--- a/notifications/src/main/kotlin/notifications/smtp/SMTPServiceImpl.kt
+++ b/notifications/src/main/kotlin/notifications/smtp/SMTPServiceImpl.kt
@@ -1,0 +1,58 @@
+package notifications.smtp
+
+import com.github.kittinunf.result.Result
+import com.github.kittinunf.result.map
+import mu.KLogging
+import notifications.config.SMTPConfig
+import java.util.*
+import javax.mail.*
+import javax.mail.internet.InternetAddress
+import javax.mail.internet.MimeBodyPart
+import javax.mail.internet.MimeMessage
+import javax.mail.internet.MimeMultipart
+
+/**
+ * Service that is used to send email messages using SMTP
+ */
+class SMTPServiceImpl(private val smtpConfig: SMTPConfig) : SMTPService {
+
+    private val properties = Properties()
+
+    init {
+        properties["mail.smtp.auth"] = true
+        properties["mail.smtp.host"] = smtpConfig.host
+        properties["mail.smtp.port"] = smtpConfig.port
+        properties["mail.smtp.ssl.trust"] = smtpConfig.host
+        properties["mail.smtp.starttls.enable"] = true
+    }
+
+    override fun sendMessage(from: String, to: String, subject: String, message: String): Result<Unit, Exception> {
+        return Result.of {
+            Session.getInstance(properties, object : Authenticator() {
+                override fun getPasswordAuthentication(): PasswordAuthentication {
+                    return PasswordAuthentication(smtpConfig.userName, smtpConfig.password)
+                }
+            })
+        }.map { session ->
+            val mimeMessage = MimeMessage(session)
+            mimeMessage.setFrom(InternetAddress(from))
+            mimeMessage.setRecipients(
+                Message.RecipientType.TO, InternetAddress.parse(to)
+            )
+            mimeMessage.subject = subject
+            val mimeBodyPart = MimeBodyPart()
+            mimeBodyPart.setContent(message, "text/html")
+            val multipart = MimeMultipart()
+            multipart.addBodyPart(mimeBodyPart)
+            mimeMessage.setContent(multipart)
+            Transport.send(mimeMessage)
+        }.map {
+            logger.info { "Message to $to has been successfully sent" }
+        }
+    }
+
+    /**
+     * Logger
+     */
+    companion object : KLogging()
+}

--- a/notifications/src/main/resources/log4j.properties
+++ b/notifications/src/main/resources/log4j.properties
@@ -1,0 +1,4 @@
+log4j.rootLogger=INFO, X
+log4j.appender.X=org.apache.log4j.ConsoleAppender
+log4j.appender.X.layout=org.apache.log4j.PatternLayout
+log4j.appender.X.layout.ConversionPattern=[%d{dd.MM.yyyy HH:mm:ss,SSS}] notifications [%-5p] [%t] %m%n

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,11 @@
 rootProject.name = 'notary'
 
+include 'notifications-integration-test'
+project(':notifications-integration-test').projectDir = 'notifications-integration-test' as File
+
+include 'notifications'
+project(':notifications').projectDir = 'notifications' as File
+
 include 'btc'
 project(':btc').projectDir = 'btc' as File
 


### PR DESCRIPTION
### Description of the Change
Notifications - is a standalone service dedicated to email notifications. It listens to Iroha blocks and notifies clients if deposit or withdrawal event occurred. We assume that client email is set by himself and stored in account details. 
We also need an SMTP server in order to make this service functioning. SMTP configurations are hidden from VCS since it holds SMTP credentials. But you can use [mailtrap.io](http://mailtrap.io) services for testing purposes(or just ask me, because I've already got mailtrap credentials). 