### PR TITLE
Fixed peer group close()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ hs_err_pid*
 /notifications/gradle
 /notifications/gradlew
 /notifications/gradlew.bat
+/notifications-integration-test/build/
 /d3testreport/gradle
 /d3testreport/gradlew
 /d3testreport/gradlew.bat

--- a/btc-deposit/src/main/kotlin/notary/btc/init/BtcNotaryInitialization.kt
+++ b/btc-deposit/src/main/kotlin/notary/btc/init/BtcNotaryInitialization.kt
@@ -115,6 +115,7 @@ class BtcNotaryInitialization(
     }
 
     override fun close() {
+        logger.info { "Closing Bitcoin notary service" }
         peerGroup.stop()
     }
 

--- a/btc-deposit/src/main/kotlin/notary/btc/listener/BitcoinTransactionListener.kt
+++ b/btc-deposit/src/main/kotlin/notary/btc/listener/BitcoinTransactionListener.kt
@@ -97,13 +97,15 @@ class BitcoinTransactionListener(
             This leads D3 to handle the same transaction many times. This is why we use a special
             flag to check if it has been handled already.
             */
-            if (confidence.depthInBlocks >= confidenceLevel
+            val currentDepth = confidence.depthInBlocks
+            if (currentDepth >= confidenceLevel
                 && processed.compareAndSet(false, true)
             ) {
                 logger.info { "BTC tx ${tx.hashAsString} was confirmed" }
                 confidence.removeEventListener(this)
                 txHandler(tx, blockTime)
             }
+            logger.info { "BTC tx ${tx.hashAsString} has $currentDepth confirmations" }
         }
     }
 

--- a/btc-withdrawal/src/main/kotlin/withdrawal/btc/init/BtcWithdrawalInitialization.kt
+++ b/btc-withdrawal/src/main/kotlin/withdrawal/btc/init/BtcWithdrawalInitialization.kt
@@ -144,6 +144,7 @@ class BtcWithdrawalInitialization(
         command.setAccountDetail.accountId.endsWith("@$BTC_SIGN_COLLECT_DOMAIN")
 
     override fun close() {
+        logger.info { "Closing Bitcoin withdrawal service" }
         peerGroup.stop()
     }
 

--- a/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/environment/BtcNotaryTestEnvironment.kt
+++ b/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/environment/BtcNotaryTestEnvironment.kt
@@ -50,7 +50,7 @@ class BtcNotaryTestEnvironment(private val integrationHelper: BtcIntegrationHelp
     private val peerGroup by lazy {
         val peerGroup = integrationHelper.getPeerGroup(
             wallet,
-            btcNetworkConfigProvider.getConfig(),
+            btcNetworkConfigProvider,
             notaryConfig.bitcoin.blockStoragePath
         )
         BitcoinConfig.extractHosts(notaryConfig.bitcoin).forEach { host ->

--- a/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/environment/BtcWithdrawalTestEnvironment.kt
+++ b/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/environment/BtcWithdrawalTestEnvironment.kt
@@ -159,7 +159,7 @@ class BtcWithdrawalTestEnvironment(private val integrationHelper: BtcIntegration
     private val peerGroup by lazy {
         val peerGroup = integrationHelper.getPeerGroup(
             wallet,
-            btcNetworkConfigProvider.getConfig(),
+            btcNetworkConfigProvider,
             btcWithdrawalConfig.bitcoin.blockStoragePath
         )
         BitcoinConfig.extractHosts(btcWithdrawalConfig.bitcoin).forEach { host ->

--- a/notary-btc-integration-test/src/main/kotlin/integration/helper/BtcIntegrationHelperUtil.kt
+++ b/notary-btc-integration-test/src/main/kotlin/integration/helper/BtcIntegrationHelperUtil.kt
@@ -6,23 +6,23 @@ import com.github.kittinunf.result.failure
 import com.github.kittinunf.result.map
 import config.BitcoinConfig
 import helper.currency.satToBtc
-import helper.network.getBlockChain
 import mu.KLogging
 import notary.IrohaCommand
 import notary.IrohaOrderedBatch
 import notary.IrohaTransaction
 import org.bitcoinj.core.Address
 import org.bitcoinj.core.ECKey
-import org.bitcoinj.core.NetworkParameters
 import org.bitcoinj.core.PeerGroup
 import org.bitcoinj.crypto.DeterministicKey
 import org.bitcoinj.params.RegTestParams
 import org.bitcoinj.script.ScriptBuilder
 import org.bitcoinj.wallet.Wallet
+import peer.SharedPeerGroup
 import provider.btc.account.IrohaBtcAccountCreator
 import provider.btc.address.AddressInfo
 import provider.btc.address.BtcAddressesProvider
 import provider.btc.address.BtcRegisteredAddressesProvider
+import provider.btc.network.BtcNetworkConfigProvider
 import registration.btc.strategy.BtcRegistrationStrategyImpl
 import sidechain.iroha.CLIENT_DOMAIN
 import sidechain.iroha.consumer.IrohaConsumerImpl
@@ -131,8 +131,12 @@ class BtcIntegrationHelperUtil : IrohaIntegrationHelperUtil() {
     /**
      * Returns group of peers
      */
-    fun getPeerGroup(wallet: Wallet, networkParameters: NetworkParameters, blockStoragePath: String): PeerGroup {
-        return PeerGroup(networkParameters, getBlockChain(wallet, networkParameters, blockStoragePath))
+    fun getPeerGroup(
+        wallet: Wallet,
+        btcNetworkConfigProvider: BtcNetworkConfigProvider,
+        blockStoragePath: String
+    ): PeerGroup {
+        return SharedPeerGroup(btcNetworkConfigProvider, wallet, blockStoragePath, emptyList())
     }
 
     private fun createMsAddress(keys: List<ECKey>): Address {


### PR DESCRIPTION
### Description of the Change
Notary(as well as Withdrawal) service tries to close itself twice: after `IrohaChainListener` failure and in `closeEnvironments()` function. Unfortunately, it causes `Exception` throw. `SharedPeerGroup` may be used instead. It can be stopped multiple times without risk of `Exception` being thrown.