### PR TITLE
SMTP dumbster integration test

### DIFF
--- a/configs/smtp_test.properties
+++ b/configs/smtp_test.properties
@@ -1,0 +1,5 @@
+# --------- SMTP -------
+smtp.host=localhost
+smtp.port=2525
+smtp.password=pass
+smtp.userName=user

--- a/notifications-integration-test/build.gradle
+++ b/notifications-integration-test/build.gradle
@@ -10,6 +10,8 @@ dependencies {
     // unit tests
     testCompile('org.junit.jupiter:junit-jupiter-api:5.2.0')
     testRuntime('org.junit.jupiter:junit-jupiter-engine:5.2.0')
+    // https://mvnrepository.com/artifact/dumbster/dumbster
+    testCompile group: 'com.github.kirviq', name: 'dumbster', version: '1.7.1'
 }
 
 sourceSets {

--- a/notifications-integration-test/src/main/kotlin/integration/helper/NotificationsConfigHelper.kt
+++ b/notifications-integration-test/src/main/kotlin/integration/helper/NotificationsConfigHelper.kt
@@ -10,7 +10,7 @@ class NotificationsConfigHelper(private val accountHelper: IrohaAccountHelper) :
     fun createNotificationsConfig(): NotificationsConfig {
         return object : NotificationsConfig {
             override val iroha = createIrohaConfig()
-            override val smtpConfigPath = "no matter. its not used in tests"
+            override val smtpConfigPath = "smtp_test.properties"
             override val notaryCredential = accountHelper.createCredentialConfig(accountHelper.notaryAccount)
         }
     }

--- a/notifications/src/main/kotlin/notifications/service/EmailNotificationService.kt
+++ b/notifications/src/main/kotlin/notifications/service/EmailNotificationService.kt
@@ -8,7 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 import provider.D3ClientProvider
 
-private const val NOTIFICATION_EMAIL = "noreply@d3.com"
+const val NOTIFICATION_EMAIL = "noreply@d3ledger.com"
 const val D3_WITHDRAWAL_EMAIL_SUBJECT = "D3 withdrawal"
 const val D3_DEPOSIT_EMAIL_SUBJECT = "D3 deposit"
 


### PR DESCRIPTION
### Description of the Change
Now we use fake SMTP server called 'Dumbster' right in `notifications` integration tests.