### PR TITLE
No more race condition in Btc registration

### DIFF
--- a/btc-address-generation/src/main/kotlin/generation/btc/config/BtcAddressGenerationConfig.kt
+++ b/btc-address-generation/src/main/kotlin/generation/btc/config/BtcAddressGenerationConfig.kt
@@ -38,4 +38,7 @@ interface BtcAddressGenerationConfig {
 
     //Minimum number of free addresses to keep in Iroha
     val threshold: Int
+
+    // Node id
+    val nodeId: String
 }

--- a/btc-address-generation/src/main/kotlin/generation/btc/config/BtcAddressGenerationConfig.kt
+++ b/btc-address-generation/src/main/kotlin/generation/btc/config/BtcAddressGenerationConfig.kt
@@ -39,6 +39,6 @@ interface BtcAddressGenerationConfig {
     //Minimum number of free addresses to keep in Iroha
     val threshold: Int
 
-    // Node id
+    // Node id 
     val nodeId: String
 }

--- a/btc-address-generation/src/main/kotlin/generation/btc/trigger/AddressGenerationTrigger.kt
+++ b/btc-address-generation/src/main/kotlin/generation/btc/trigger/AddressGenerationTrigger.kt
@@ -31,15 +31,17 @@ class AddressGenerationTrigger(
      * Starts address generation process
      * @param addressType - type of address to generate
      * @param addressesToGenerate - number of addresses to generate. 1 by default.
+     * @param nodeId - node id
      */
     fun startAddressGeneration(
         addressType: BtcAddressType,
-        addressesToGenerate: Int = 1
+        addressesToGenerate: Int = 1,
+        nodeId: String
     ): Result<Unit, Exception> {
         val txList = ArrayList<IrohaTransaction>()
         for (addresses in 1..addressesToGenerate) {
             val sessionAccountName = addressType.createSessionAccountName()
-            txList.add(btcSessionProvider.createPubKeyCreationSessionTx(sessionAccountName))
+            txList.add(btcSessionProvider.createPubKeyCreationSessionTx(sessionAccountName, nodeId))
             txList.add(
                 btcAddressGenerationTriggerProvider.triggerTx(
                     sessionAccountName
@@ -55,13 +57,14 @@ class AddressGenerationTrigger(
      * Starts free address generation process, if there is a need to generate.
      * Addresses will be generated if there is not enough free addresses in Iroha.
      * @param addressesThreshold - minimum number of free addresses to keep in Iroha
+     * @param nodeId - node id
      */
-    fun startFreeAddressGenerationIfNeeded(addressesThreshold: Int): Result<Unit, Exception> {
+    fun startFreeAddressGenerationIfNeeded(addressesThreshold: Int, nodeId: String): Result<Unit, Exception> {
         return btcFreeAddressesProvider.getFreeAddresses().flatMap { freeAddresses ->
             if (freeAddresses.size < addressesThreshold) {
                 val addressesToGenerate = addressesThreshold - freeAddresses.size
                 logger.info { "Generating $addressesToGenerate addresses" }
-                startAddressGeneration(BtcAddressType.FREE, addressesToGenerate)
+                startAddressGeneration(BtcAddressType.FREE, addressesToGenerate, nodeId)
             } else {
                 logger.info { "No need to generate addresses" }
                 Result.of { Unit }

--- a/btc-address-generation/src/main/kotlin/generation/btc/trigger/BtcAddressGenerationTriggerAppConfiguration.kt
+++ b/btc-address-generation/src/main/kotlin/generation/btc/trigger/BtcAddressGenerationTriggerAppConfiguration.kt
@@ -81,5 +81,9 @@ class BtcAddressGenerationTriggerAppConfiguration {
 
     @Bean
     fun btcFreeAddressesProvider() =
-        BtcFreeAddressesProvider(btcAddressesProvider(), btcRegisteredAddressesProvider())
+        BtcFreeAddressesProvider(
+            btcAddressGenerationTriggerConfig.nodeId,
+            btcAddressesProvider(),
+            btcRegisteredAddressesProvider()
+        )
 }

--- a/btc-address-generation/src/main/kotlin/generation/btc/trigger/ChangeAddressGeneration.kt
+++ b/btc-address-generation/src/main/kotlin/generation/btc/trigger/ChangeAddressGeneration.kt
@@ -21,7 +21,11 @@ fun main(args: Array<String>) {
     Result.of {
         AnnotationConfigApplicationContext(BtcChangeAddressGenerationApplication::class.java)
     }.flatMap { context ->
-        context.getBean(AddressGenerationTrigger::class.java).startAddressGeneration(addressType)
+        context.getBean(AddressGenerationTrigger::class.java)
+            .startAddressGeneration(
+                addressType = addressType,
+                nodeId = btcAddressGenerationTriggerConfig.nodeId
+            )
     }.fold(
         {
             logger.info { "${addressType.title} address generation process was started" }

--- a/btc-address-generation/src/main/kotlin/generation/btc/trigger/FreeAddressGeneration.kt
+++ b/btc-address-generation/src/main/kotlin/generation/btc/trigger/FreeAddressGeneration.kt
@@ -21,7 +21,10 @@ fun main(args: Array<String>) {
     Result.of {
         AnnotationConfigApplicationContext(BtcFreeAddressGenerationApplication::class.java)
     }.flatMap { context ->
-        context.getBean(AddressGenerationTrigger::class.java).startAddressGeneration(addressType)
+        context.getBean(AddressGenerationTrigger::class.java).startAddressGeneration(
+            addressType = addressType,
+            nodeId = btcAddressGenerationTriggerConfig.nodeId
+        )
     }.fold(
         {
             logger.info { "${addressType.title} address generation process was started" }

--- a/btc-deposit/src/main/kotlin/notary/btc/listener/BitcoinTransactionListener.kt
+++ b/btc-deposit/src/main/kotlin/notary/btc/listener/BitcoinTransactionListener.kt
@@ -73,12 +73,13 @@ class BitcoinTransactionListener(
                     Subtracting 2 hours is just a simple workaround of this problem.
                     */
                     BigInteger.valueOf(blockTime.time - TWO_HOURS_MILLIS),
-                    btcAddress.info.irohaClient,
+                    btcAddress.info.irohaClient!!,
                     BTC_ASSET_NAME,
                     btcValue.toPlainString(),
                     ""
                 )
-                logger.info { "BTC deposit event(tx ${tx.hashAsString}, amount ${btcValue.toPlainString()}) was created. Related client is ${btcAddress.info.irohaClient}. " }
+                logger.info { "BTC deposit event(tx ${tx.hashAsString}, amount ${btcValue.toPlainString()}) was created. " +
+                        "Related client is ${btcAddress.info.irohaClient}. " }
                 emitter.onNext(event)
             }
         }

--- a/btc-registration/src/main/kotlin/com/d3/btc/registration/config/BtcRegistrationAppConfiguration.kt
+++ b/btc-registration/src/main/kotlin/com/d3/btc/registration/config/BtcRegistrationAppConfiguration.kt
@@ -1,5 +1,6 @@
 package com.d3.btc.registration.config
 
+import com.d3.btc.provider.BtcFreeAddressesProvider
 import com.d3.btc.provider.BtcRegisteredAddressesProvider
 import com.d3.btc.provider.account.IrohaBtcAccountCreator
 import com.d3.btc.provider.address.BtcAddressesProvider
@@ -42,20 +43,19 @@ class BtcRegistrationAppConfiguration {
     fun btcRegistrationConfig() = btcRegistrationConfig
 
     @Bean
-    fun btcAddressesProvider(): BtcAddressesProvider {
-        return BtcAddressesProvider(
-            queryAPI(),
-            btcRegistrationConfig.mstRegistrationAccount,
-            btcRegistrationConfig.notaryAccount
-        )
-    }
-
-    @Bean
-    fun btcRegisteredAddressesProvider(): BtcRegisteredAddressesProvider {
-        return BtcRegisteredAddressesProvider(
-            queryAPI(),
-            btcRegistrationCredential.accountId,
-            btcRegistrationConfig.notaryAccount
+    fun btcFreeAddressesProvider(): BtcFreeAddressesProvider {
+        return BtcFreeAddressesProvider(
+            btcRegistrationConfig.nodeId,
+            BtcAddressesProvider(
+                queryAPI(),
+                btcRegistrationConfig.mstRegistrationAccount,
+                btcRegistrationConfig.notaryAccount
+            ),
+            BtcRegisteredAddressesProvider(
+                queryAPI(),
+                btcRegistrationCredential.accountId,
+                btcRegistrationConfig.notaryAccount
+            )
         )
     }
 

--- a/btc-registration/src/main/kotlin/com/d3/btc/registration/config/BtcRegistrationConfig.kt
+++ b/btc-registration/src/main/kotlin/com/d3/btc/registration/config/BtcRegistrationConfig.kt
@@ -24,4 +24,7 @@ interface BtcRegistrationConfig {
 
     /** Port for health check service */
     val healthCheckPort: Int
+
+    /** Node id */
+    val nodeId: String
 }

--- a/btc/src/main/kotlin/com/d3/btc/model/BtcAddress.kt
+++ b/btc/src/main/kotlin/com/d3/btc/model/BtcAddress.kt
@@ -5,18 +5,24 @@ import util.irohaEscape
 
 private val addressInfoJsonAdapter = Moshi.Builder().build().adapter(AddressInfo::class.java)
 
-data class BtcAddress(val address: String, val info: AddressInfo) {
-    fun isFree() = this.info.irohaClient == BtcAddressType.FREE.title
-    fun isChange() = this.info.irohaClient == BtcAddressType.CHANGE.title
-}
+data class BtcAddress(val address: String, val info: AddressInfo)
 
-data class AddressInfo(val irohaClient: String, val notaryKeys: List<String>) {
+/**
+ * Data class that holds information about address
+ * @param irohaClient - address owner Iroha client id
+ * @param notaryKeys - keys that were used to create this address
+ * @param nodeId - id of node that created this address
+ */
+data class AddressInfo(val irohaClient: String?, val notaryKeys: List<String>, val nodeId: String) {
 
     fun toJson() = addressInfoJsonAdapter.toJson(this).irohaEscape()
 
     companion object {
         fun fromJson(json: String) = addressInfoJsonAdapter.fromJson(json)
-        fun createFreeAddressInfo(notaryKeys: List<String>) = AddressInfo(BtcAddressType.FREE.title, notaryKeys)
-        fun createChangeAddressInfo(notaryKeys: List<String>) = AddressInfo(BtcAddressType.CHANGE.title, notaryKeys)
+        fun createFreeAddressInfo(notaryKeys: List<String>, nodeId: String) =
+            AddressInfo(null, notaryKeys, nodeId)
+
+        fun createChangeAddressInfo(notaryKeys: List<String>, nodeId: String) =
+            AddressInfo(null, notaryKeys, nodeId)
     }
 }

--- a/btc/src/main/kotlin/com/d3/btc/provider/account/IrohaBtcAccountCreator.kt
+++ b/btc/src/main/kotlin/com/d3/btc/provider/account/IrohaBtcAccountCreator.kt
@@ -25,6 +25,7 @@ class IrohaBtcAccountCreator(
      * @param domain - client domain
      * @param pubkey - client's public key
      * @param notaryKeys - keys that were used to create given address
+     * @param nodeId - node id
      * @return address associated with userName
      */
     fun create(
@@ -33,7 +34,8 @@ class IrohaBtcAccountCreator(
         userName: String,
         domain: String,
         pubkey: String,
-        notaryKeys: List<String>
+        notaryKeys: List<String>,
+        nodeId: String
     ): Result<String, Exception> {
         return irohaAccountCreator.create(
             btcAddress,
@@ -45,7 +47,8 @@ class IrohaBtcAccountCreator(
         ) {
             AddressInfo(
                 "$userName@$domain",
-                notaryKeys
+                notaryKeys,
+                nodeId
             ).toJson()
         }
     }

--- a/configs/btc/address_generation_local.properties
+++ b/configs/btc/address_generation_local.properties
@@ -5,7 +5,9 @@ btc-address-generation.notaryListStorageAccount=notaries@notary
 btc-address-generation.healthCheckPort=7071
 btc-address-generation.notaryListSetterAccount=notary@notary
 btc-address-generation.changeAddressesStorageAccount=btc_change_addresses@notary
-btc-address-generation.threshold=5
+btc-address-generation.threshold=2
+# Node id. Every node MUST have its own unique id
+btc-address-generation.nodeId=1
 # --------- Credentials ----------
 btc-address-generation.registrationAccount.accountId=btc_registration_service@notary
 btc-address-generation.registrationAccount.pubkeyPath=deploy/iroha/keys/btc_registration_service@notary.pub

--- a/configs/btc/address_generation_mainnet.properties
+++ b/configs/btc/address_generation_mainnet.properties
@@ -5,7 +5,9 @@ btc-address-generation.notaryListStorageAccount=notaries@notary
 btc-address-generation.healthCheckPort=7071
 btc-address-generation.notaryListSetterAccount=notary@notary
 btc-address-generation.changeAddressesStorageAccount=btc_change_addresses@notary
-btc-address-generation.threshold=5
+btc-address-generation.threshold=2
+# Node id. Every node MUST have its own unique id
+btc-address-generation.nodeId=1
 # --------- Credentials ----------
 btc-address-generation.registrationAccount.accountId=btc_registration_service@notary
 btc-address-generation.registrationAccount.pubkeyPath=deploy/iroha/keys/btc_registration_service@notary.pub

--- a/configs/btc/address_generation_testnet.properties
+++ b/configs/btc/address_generation_testnet.properties
@@ -5,7 +5,9 @@ btc-address-generation.notaryListStorageAccount=notaries@notary
 btc-address-generation.healthCheckPort=7071
 btc-address-generation.notaryListSetterAccount=notary@notary
 btc-address-generation.changeAddressesStorageAccount=btc_change_addresses@notary
-btc-address-generation.threshold=5
+btc-address-generation.threshold=2
+# Node id. Every node MUST have its own unique id
+btc-address-generation.nodeId=1
 # --------- Credentials ----------
 btc-address-generation.registrationAccount.accountId=btc_registration_service@notary
 btc-address-generation.registrationAccount.pubkeyPath=deploy/iroha/keys/btc_registration_service@notary.pub

--- a/configs/btc/registration_local.properties
+++ b/configs/btc/registration_local.properties
@@ -2,6 +2,8 @@
 btc-registration.registrationAccount=btc_registration_service@notary
 btc-registration.mstRegistrationAccount=mst_btc_registration_service@notary
 btc-registration.notaryAccount=notary@notary
+# Node id. Every node MUST have its own unique id
+btc-registration.nodeId=1
 # port of registration service
 btc-registration.port=8086
 btc-registration.healthCheckPort=7072

--- a/configs/btc/registration_mainnet.properties
+++ b/configs/btc/registration_mainnet.properties
@@ -2,6 +2,8 @@
 btc-registration.registrationAccount=btc_registration_service@notary
 btc-registration.mstRegistrationAccount=mst_btc_registration_service@notary
 btc-registration.notaryAccount=notary@notary
+# Node id. Every node MUST have its own unique id
+btc-registration.nodeId=1
 # port of registration service
 btc-registration.port=8086
 btc-registration.healthCheckPort=7072

--- a/configs/btc/registration_testnet.properties
+++ b/configs/btc/registration_testnet.properties
@@ -2,6 +2,8 @@
 btc-registration.registrationAccount=btc_registration_service@notary
 btc-registration.mstRegistrationAccount=mst_btc_registration_service@notary
 btc-registration.notaryAccount=notary@notary
+# Node id. Every node MUST have its own unique id
+btc-registration.nodeId=1
 # port of registration service
 btc-registration.port=8086
 btc-registration.healthCheckPort=7072

--- a/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/BtcAddressGenerationIntegrationTest.kt
+++ b/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/BtcAddressGenerationIntegrationTest.kt
@@ -2,6 +2,7 @@ package integration.btc
 
 import com.d3.btc.model.AddressInfo
 import com.d3.btc.model.BtcAddressType
+import com.d3.btc.provider.generation.ADDRESS_GENERATION_NODE_ID_KEY
 import com.d3.btc.provider.generation.ADDRESS_GENERATION_TIME_KEY
 import com.github.kittinunf.result.failure
 import integration.btc.environment.BtcAddressGenerationTestEnvironment
@@ -20,11 +21,14 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.fail
 import java.io.File
+import java.util.*
 
 const val WAIT_PREGEN_PROCESS_MILLIS = 20_000L
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class BtcAddressGenerationIntegrationTest {
+
+    private val nodeId = UUID.randomUUID()
 
     private val integrationHelper = BtcIntegrationHelperUtil()
 
@@ -57,7 +61,6 @@ class BtcAddressGenerationIntegrationTest {
     }
 
     /**
-     * Test US-001 btc addresses generation
      * Note: Iroha must be deployed to pass the test.
      * @given "free" session account is created
      * @when special generation account is triggered
@@ -66,9 +69,11 @@ class BtcAddressGenerationIntegrationTest {
     @Test
     fun testGenerateFreeAddress() {
         val sessionAccountName = BtcAddressType.FREE.createSessionAccountName()
-        environment.btcKeyGenSessionProvider.createPubKeyCreationSession(sessionAccountName)
-            .fold({ logger.info { "session $sessionAccountName was created" } },
-                { ex -> fail("cannot create session", ex) })
+        environment.btcKeyGenSessionProvider.createPubKeyCreationSession(
+            sessionAccountName,
+            nodeId.toString()
+        ).fold({ logger.info { "session $sessionAccountName was created" } },
+            { ex -> fail("cannot create session", ex) })
         environment.triggerProvider.trigger(sessionAccountName)
         Thread.sleep(WAIT_PREGEN_PROCESS_MILLIS)
         val sessionDetails =
@@ -76,8 +81,11 @@ class BtcAddressGenerationIntegrationTest {
                 "$sessionAccountName@btcSession",
                 environment.btcGenerationConfig.registrationAccount.accountId
             )
-        val notaryKeys = sessionDetails.entries.filter { entry -> entry.key != ADDRESS_GENERATION_TIME_KEY }
-            .map { entry -> entry.value }
+        val notaryKeys =
+            sessionDetails.entries.filter { entry ->
+                entry.key != ADDRESS_GENERATION_TIME_KEY
+                        && entry.key != ADDRESS_GENERATION_NODE_ID_KEY
+            }.map { entry -> entry.value }
         val pubKey = notaryKeys.first()
         assertNotNull(pubKey)
         val wallet = Wallet.loadFromFile(File(environment.btcGenerationConfig.btcWalletFilePath))
@@ -89,8 +97,9 @@ class BtcAddressGenerationIntegrationTest {
             )
         val expectedMsAddress = createMsAddress(notaryKeys)
         val generatedAddress = AddressInfo.fromJson(notaryAccountDetails[expectedMsAddress]!!)!!
-        assertEquals(BtcAddressType.FREE.title, generatedAddress.irohaClient)
+        assertNull(generatedAddress.irohaClient)
         assertEquals(notaryKeys, generatedAddress.notaryKeys.toList())
+        assertEquals(nodeId.toString(), generatedAddress.nodeId)
     }
 
     /**
@@ -102,9 +111,11 @@ class BtcAddressGenerationIntegrationTest {
     @Test
     fun testGenerateChangeAddress() {
         val sessionAccountName = BtcAddressType.CHANGE.createSessionAccountName()
-        environment.btcKeyGenSessionProvider.createPubKeyCreationSession(sessionAccountName)
-            .fold({ logger.info { "session $sessionAccountName was created" } },
-                { ex -> fail("cannot create session", ex) })
+        environment.btcKeyGenSessionProvider.createPubKeyCreationSession(
+            sessionAccountName,
+            nodeId.toString()
+        ).fold({ logger.info { "session $sessionAccountName was created" } },
+            { ex -> fail("cannot create session", ex) })
         environment.triggerProvider.trigger(sessionAccountName)
         Thread.sleep(WAIT_PREGEN_PROCESS_MILLIS)
         val sessionDetails =
@@ -112,8 +123,11 @@ class BtcAddressGenerationIntegrationTest {
                 "$sessionAccountName@btcSession",
                 environment.btcGenerationConfig.registrationAccount.accountId
             )
-        val notaryKeys = sessionDetails.entries.filter { entry -> entry.key != ADDRESS_GENERATION_TIME_KEY }
-            .map { entry -> entry.value }
+        val notaryKeys =
+            sessionDetails.entries.filter { entry ->
+                entry.key != ADDRESS_GENERATION_TIME_KEY
+                        && entry.key != ADDRESS_GENERATION_NODE_ID_KEY
+            }.map { entry -> entry.value }
         val pubKey = notaryKeys.first()
         assertNotNull(pubKey)
         val wallet = Wallet.loadFromFile(File(environment.btcGenerationConfig.btcWalletFilePath))
@@ -125,8 +139,9 @@ class BtcAddressGenerationIntegrationTest {
             )
         val expectedMsAddress = createMsAddress(notaryKeys)
         val generatedAddress = AddressInfo.fromJson(changeAddressStorageAccountDetails[expectedMsAddress]!!)!!
-        assertEquals(BtcAddressType.CHANGE.title, generatedAddress.irohaClient)
+        assertNull(generatedAddress.irohaClient)
         assertEquals(notaryKeys, generatedAddress.notaryKeys.toList())
+        assertEquals(nodeId.toString(), generatedAddress.nodeId)
     }
 
     /**

--- a/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/BtcFullPipelineTest.kt
+++ b/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/BtcFullPipelineTest.kt
@@ -239,9 +239,11 @@ class BtcFullPipelineTest {
      */
     private fun generateAddress(addressType: BtcAddressType) {
         val sessionAccountName = addressType.createSessionAccountName()
-        addressGenerationEnvironment.btcKeyGenSessionProvider.createPubKeyCreationSession(sessionAccountName)
-            .fold({ logger.info { "session $sessionAccountName was created" } },
-                { ex -> fail("cannot create session", ex) })
+        addressGenerationEnvironment.btcKeyGenSessionProvider.createPubKeyCreationSession(
+            sessionAccountName,
+            addressGenerationEnvironment.btcGenerationConfig.nodeId
+        ).fold({ logger.info { "session $sessionAccountName was created" } },
+            { ex -> fail("cannot create session", ex) })
         addressGenerationEnvironment.triggerProvider.trigger(sessionAccountName)
         Thread.sleep(WAIT_PREGEN_PROCESS_MILLIS)
     }

--- a/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/BtcRegistrationIntegrationTest.kt
+++ b/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/BtcRegistrationIntegrationTest.kt
@@ -34,7 +34,6 @@ class BtcRegistrationIntegrationTest {
     }
 
     /**
-     * Test US-001 Client registration
      * Note: Iroha must be deployed to pass the test.
      * @given new client
      * @when client name is passed to registration service
@@ -64,7 +63,30 @@ class BtcRegistrationIntegrationTest {
     }
 
     /**
-     * Test US-002 Client registration
+     * Note: Iroha must be deployed to pass the test.
+     * @given new client, but no free addresses for my node
+     * @when client name is passed to registration service
+     * @then client stays unregistered
+     */
+    @Test
+    fun testRegistrationNoAddressForMyNode() {
+        val clientsBeforeRegistration = environment.btcTakenAddressesProvider.getRegisteredAddresses().get().size
+        integrationHelper.genFreeBtcAddress(environment.btcNotaryConfig.bitcoin.walletPath, "different node id")
+        val keypair = Ed25519Sha3().generateKeypair()
+        val userName = String.getRandomString(9)
+        val res = khttp.post(
+            "http://127.0.0.1:${environment.btcRegistrationConfig.port}/users",
+            data = mapOf("name" to userName, "pubkey" to keypair.public.toHexString())
+        )
+
+        assertEquals(500, res.statusCode)
+        assertEquals(
+            clientsBeforeRegistration,
+            environment.btcTakenAddressesProvider.getRegisteredAddresses().get().size
+        )
+    }
+
+    /**
      * Note: Iroha must be deployed to pass the test.
      * @given multiple clients
      * @when client names are passed to registration service
@@ -107,7 +129,6 @@ class BtcRegistrationIntegrationTest {
     }
 
     /**
-     * Test US-002 Client registration
      * Note: Iroha must be deployed to pass the test.
      * @given no registered btc addreses
      * @when client name is passed to registration service
@@ -159,5 +180,4 @@ class BtcRegistrationIntegrationTest {
             environment.btcTakenAddressesProvider.getRegisteredAddresses().get().size
         )
     }
-
 }

--- a/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/environment/BtcAddressGenerationTestEnvironment.kt
+++ b/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/environment/BtcAddressGenerationTestEnvironment.kt
@@ -139,7 +139,7 @@ class BtcAddressGenerationTestEnvironment(
     )
 
     val btcFreeAddressesProvider =
-        BtcFreeAddressesProvider(btcAddressesProvider, btcRegisteredAddressesProvider)
+        BtcFreeAddressesProvider(btcGenerationConfig.nodeId, btcAddressesProvider, btcRegisteredAddressesProvider)
 
     private val addressGenerationTrigger = AddressGenerationTrigger(
         btcKeyGenSessionProvider,

--- a/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/environment/BtcRegistrationTestEnvironment.kt
+++ b/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/environment/BtcRegistrationTestEnvironment.kt
@@ -1,5 +1,6 @@
 package integration.btc.environment
 
+import com.d3.btc.provider.BtcFreeAddressesProvider
 import com.d3.btc.provider.BtcRegisteredAddressesProvider
 import com.d3.btc.provider.account.IrohaBtcAccountCreator
 import com.d3.btc.provider.address.BtcAddressesProvider
@@ -35,8 +36,10 @@ class BtcRegistrationTestEnvironment(private val integrationHelper: BtcIntegrati
     val btcRegistrationServiceInitialization = BtcRegistrationServiceInitialization(
         btcRegistrationConfig,
         BtcRegistrationStrategyImpl(
-            btcAddressesProvider(),
-            btcRegisteredAddressesProvider(),
+            BtcFreeAddressesProvider(
+                btcRegistrationConfig.nodeId, btcAddressesProvider(),
+                btcRegisteredAddressesProvider()
+            ),
             irohaBtcAccountCreator()
         )
     )

--- a/notary-btc-integration-test/src/main/kotlin/integration/helper/BtcConfigHelper.kt
+++ b/notary-btc-integration-test/src/main/kotlin/integration/helper/BtcConfigHelper.kt
@@ -32,6 +32,7 @@ class BtcConfigHelper(
 
         return object : BtcAddressGenerationConfig {
             override val threshold = initAddresses
+            override val nodeId = NODE_ID
             override val changeAddressesStorageAccount = accountHelper.changeAddressesStorageAccount.accountId
             override val healthCheckPort = btcPkPreGenConfig.healthCheckPort
             override val notaryListStorageAccount = accountHelper.notaryListStorageAccount.accountId
@@ -141,6 +142,7 @@ class BtcConfigHelper(
         val btcRegistrationConfig =
             loadConfigs("btc-registration", BtcRegistrationConfig::class.java, "/btc/registration.properties").get()
         return object : BtcRegistrationConfig {
+            override val nodeId = NODE_ID
             override val healthCheckPort = btcRegistrationConfig.healthCheckPort
             override val notaryAccount = accountHelper.notaryAccount.accountId
             override val mstRegistrationAccount = accountHelper.mstRegistrationAccount.accountId
@@ -150,5 +152,4 @@ class BtcConfigHelper(
             override val iroha = createIrohaConfig()
         }
     }
-
 }

--- a/notary-btc-integration-test/src/main/kotlin/integration/helper/BtcIntegrationHelperUtil.kt
+++ b/notary-btc-integration-test/src/main/kotlin/integration/helper/BtcIntegrationHelperUtil.kt
@@ -3,6 +3,7 @@ package integration.helper
 import com.d3.btc.helper.currency.satToBtc
 import com.d3.btc.model.AddressInfo
 import com.d3.btc.peer.SharedPeerGroup
+import com.d3.btc.provider.BtcFreeAddressesProvider
 import com.d3.btc.provider.BtcRegisteredAddressesProvider
 import com.d3.btc.provider.account.IrohaBtcAccountCreator
 import com.d3.btc.provider.address.BtcAddressesProvider
@@ -33,8 +34,13 @@ import java.io.File
 import java.math.BigDecimal
 import java.security.KeyPair
 
+// Btc asset id
 const val BTC_ASSET = "btc#bitcoin"
+// Default node id
+const val NODE_ID = "any id"
+// How many address may be generated in one batch
 private const val GENERATED_ADDRESSES_PER_BATCH = 5
+// How many blocks to generate to make Bitcoin regtest node able to send money
 private const val BTC_INITAL_BLOCKS = 101
 
 class BtcIntegrationHelperUtil(peers: Int = 1) : IrohaIntegrationHelperUtil(peers) {
@@ -73,8 +79,11 @@ class BtcIntegrationHelperUtil(peers: Int = 1) : IrohaIntegrationHelperUtil(peer
             accountHelper.notaryAccount.accountId
         )
         BtcRegistrationStrategyImpl(
-            btcAddressesProvider,
-            btcTakenAddressesProvider,
+            BtcFreeAddressesProvider(
+                NODE_ID,
+                btcAddressesProvider,
+                btcTakenAddressesProvider
+            ),
             irohaBtcAccountCreator
         )
     }
@@ -118,7 +127,7 @@ class BtcIntegrationHelperUtil(peers: Int = 1) : IrohaIntegrationHelperUtil(peer
                     IrohaCommand.CommandSetAccountDetail(
                         accountHelper.notaryAccount.accountId,
                         address.toBase58(),
-                        AddressInfo.createFreeAddressInfo(listOf(key.publicKeyAsHex)).toJson()
+                        AddressInfo.createFreeAddressInfo(listOf(key.publicKeyAsHex), NODE_ID).toJson()
                     )
                 )
             )
@@ -148,15 +157,16 @@ class BtcIntegrationHelperUtil(peers: Int = 1) : IrohaIntegrationHelperUtil(peer
     /**
      * Generates one BTC address that can be registered later
      * @param walletFilePath - path to wallet file
+     * @param nodeId - node id. NODE_ID by default
      * @return randomly generated BTC address
      */
-    fun genFreeBtcAddress(walletFilePath: String): Result<Address, Exception> {
+    fun genFreeBtcAddress(walletFilePath: String, nodeId: String = NODE_ID): Result<Address, Exception> {
         val (key, address) = generateKeyAndAddress(walletFilePath)
         return ModelUtil.setAccountDetail(
             mstRegistrationIrohaConsumer,
             accountHelper.notaryAccount.accountId,
             address.toBase58(),
-            AddressInfo.createFreeAddressInfo(listOf(key.publicKeyAsHex)).toJson()
+            AddressInfo.createFreeAddressInfo(listOf(key.publicKeyAsHex), nodeId).toJson()
         ).map { address }
     }
 
@@ -171,7 +181,7 @@ class BtcIntegrationHelperUtil(peers: Int = 1) : IrohaIntegrationHelperUtil(peer
             mstRegistrationIrohaConsumer,
             accountHelper.changeAddressesStorageAccount.accountId,
             address.toBase58(),
-            AddressInfo.createChangeAddressInfo(listOf(key.publicKeyAsHex)).toJson()
+            AddressInfo.createChangeAddressInfo(listOf(key.publicKeyAsHex), NODE_ID).toJson()
         ).map { address }
     }
 


### PR DESCRIPTION
### Description of the Change
No more race conditions in Bitcoin registration service. This is how we can approach it:
1) Make registration `synchronized`, so no other thread within node will be able to register the same address
2) Make it able to register node owned addresses only, so no other node with different id will register the same address.