### PR TITLE
Splitting Iroha chain listener

### DIFF
--- a/btc-address-generation/src/main/kotlin/com/d3/btc/generation/init/BtcAddressGenerationInitialization.kt
+++ b/btc-address-generation/src/main/kotlin/com/d3/btc/generation/init/BtcAddressGenerationInitialization.kt
@@ -45,7 +45,7 @@ class BtcAddressGenerationInitialization(
     If trigger account is triggered, new session account full notary public keys will be created
      */
     fun init(): Result<Unit, Exception> {
-        return irohaChainListener.getIrohaBlockObservable()
+        return irohaChainListener.getBlockObservable()
             .map { irohaObservable ->
                 initIrohaObservable(irohaObservable)
             }.flatMap {

--- a/btc-deposit/src/main/kotlin/com/d3/btc/deposit/init/BtcNotaryInitialization.kt
+++ b/btc-deposit/src/main/kotlin/com/d3/btc/deposit/init/BtcNotaryInitialization.kt
@@ -61,7 +61,7 @@ class BtcNotaryInitialization(
         //Enables short log format for Bitcoin events
         BriefLogFormatter.init()
         addPeerConnectionStatusListener(peerGroup, ::notHealthy, ::cured)
-        return irohaChainListener.getIrohaBlockObservable().map { irohaObservable ->
+        return irohaChainListener.getBlockObservable().map { irohaObservable ->
             newBtcClientRegistrationListener.listenToRegisteredClients(
                 wallet, irohaObservable
             ) {

--- a/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/init/BtcWithdrawalInitialization.kt
+++ b/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/init/BtcWithdrawalInitialization.kt
@@ -94,7 +94,7 @@ class BtcWithdrawalInitialization(
         irohaChainListener: IrohaChainListener,
         peerGroup: PeerGroup
     ): Result<Unit, Exception> {
-        return irohaChainListener.getIrohaBlockObservable().map { irohaObservable ->
+        return irohaChainListener.getBlockObservable().map { irohaObservable ->
             irohaObservable.subscribeOn(Schedulers.single())
                 .subscribe({ block ->
                     // Handle transfer commands

--- a/eth-withdrawal/src/main/kotlin/withdrawalservice/WithdrawalServiceInitialization.kt
+++ b/eth-withdrawal/src/main/kotlin/withdrawalservice/WithdrawalServiceInitialization.kt
@@ -14,7 +14,7 @@ import mu.KLogging
 import sidechain.SideChainEvent
 import sidechain.eth.consumer.EthConsumer
 import sidechain.iroha.IrohaChainHandler
-import sidechain.iroha.IrohaChainListener
+import sidechain.iroha.ReliableIrohaChainListener
 import vacuum.RelayVacuumConfig
 
 /**
@@ -38,10 +38,9 @@ class WithdrawalServiceInitialization(
      */
     private fun initIrohaChain(): Result<Observable<SideChainEvent.IrohaEvent>, Exception> {
         logger.info { "Init Iroha chain listener" }
-        return IrohaChainListener(
+        return ReliableIrohaChainListener(
             irohaHost,
             irohaPort,
-            credential,
             rmqConfig,
             withdrawalConfig.ethIrohaWithdrawalQueue
         ).getBlockObservable()

--- a/eth-withdrawal/src/main/kotlin/withdrawalservice/WithdrawalServiceInitialization.kt
+++ b/eth-withdrawal/src/main/kotlin/withdrawalservice/WithdrawalServiceInitialization.kt
@@ -29,8 +29,6 @@ class WithdrawalServiceInitialization(
     private val relayVacuumConfig: RelayVacuumConfig,
     private val rmqConfig: RMQConfig
 ) {
-    private val irohaHost = withdrawalConfig.iroha.hostname
-    private val irohaPort = withdrawalConfig.iroha.port
 
     /**
      * Init Iroha chain listener
@@ -39,8 +37,6 @@ class WithdrawalServiceInitialization(
     private fun initIrohaChain(): Result<Observable<SideChainEvent.IrohaEvent>, Exception> {
         logger.info { "Init Iroha chain listener" }
         return ReliableIrohaChainListener(
-            irohaHost,
-            irohaPort,
             rmqConfig,
             withdrawalConfig.ethIrohaWithdrawalQueue
         ).getBlockObservable()

--- a/notary-commons/src/main/kotlin/sidechain/iroha/IrohaChainListener.kt
+++ b/notary-commons/src/main/kotlin/sidechain/iroha/IrohaChainListener.kt
@@ -1,60 +1,30 @@
 package sidechain.iroha
 
-import config.RMQConfig
 import com.github.kittinunf.result.Result
 import com.github.kittinunf.result.map
-import com.rabbitmq.client.*
+import io.reactivex.Observable
+import iroha.protocol.BlockOuterClass
 import jp.co.soramitsu.iroha.java.IrohaAPI
 import model.IrohaCredential
 import mu.KLogging
 import sidechain.ChainListener
 import sidechain.iroha.util.ModelUtil
-import io.reactivex.Observable
-import io.reactivex.subjects.PublishSubject
-import kotlin.test.assertNotNull
 
 /**
- * Dummy implementation of [ChainListener] with effective dependencies
+ * Plain implementation of [ChainListener] with effective dependencies
  */
 class IrohaChainListener(
     private val irohaAPI: IrohaAPI,
-    private val credential: IrohaCredential,
-    private val rmqConfig: RMQConfig? = null,
-    private val irohaQueue: String? = null
-) : ChainListener<Pair<iroha.protocol.BlockOuterClass.Block, () -> Unit>> {
-
+    private val credential: IrohaCredential
+) : ChainListener<iroha.protocol.BlockOuterClass.Block> {
     constructor(
         irohaHost: String,
         irohaPort: Int,
-        credential: IrohaCredential,
-        rmqConfig: RMQConfig? = null,
-        irohaQueue: String? = null
-    ) : this(IrohaAPI(irohaHost, irohaPort), credential, rmqConfig, irohaQueue)
+        credential: IrohaCredential
+    ) : this(IrohaAPI(irohaHost, irohaPort), credential)
 
-    private val factory by lazy { ConnectionFactory() }
-
-    private val conn by lazy {
-        factory.host = rmqConfig?.host
-        factory.newConnection()
-    }
-
-    private val channel by lazy { conn.createChannel() }
-
-    var consumerTag: String? = null
-
-    init {
-        rmqConfig?.let {
-            irohaQueue?.let {
-                channel.exchangeDeclare(rmqConfig.irohaExchange, "fanout", true)
-                channel.queueDeclare(irohaQueue, true, false, false, null)
-                channel.queueBind(irohaQueue, rmqConfig.irohaExchange, "")
-                channel.basicQos(1)
-            }
-        }
-    }
-
-    @Deprecated("This method connects directly to iroha, we will switch to MQ soon")
-    fun getIrohaBlockObservable(): Result<Observable<iroha.protocol.BlockOuterClass.Block>, Exception> {
+    override fun getBlockObservable(autoAck: Boolean): Result<Observable<BlockOuterClass.Block>, Exception> {
+        logger.info { "On subscribe to Iroha chain" }
         return ModelUtil.getBlockStreaming(irohaAPI, credential).map { observable ->
             observable.map { response ->
                 logger.info { "New Iroha block arrived. Height ${response.blockResponse.block.blockV1.payload.height}" }
@@ -63,63 +33,12 @@ class IrohaChainListener(
         }
     }
 
-    /**
-     * Returns an observable that emits a new block every time it gets it from Iroha
-     */
-    override fun getBlockObservable(autoAck: Boolean): Result<Observable<Pair<iroha.protocol.BlockOuterClass.Block, () -> Unit>>, Exception> {
-        assertNotNull(rmqConfig)
-        assertNotNull(irohaQueue)
-
-        val source = PublishSubject.create<Delivery>()
-        val obs: Observable<Delivery> = source
-        channel.queueDeclare(irohaQueue, true, false, false, null)
-        val deliverCallback = { consumerTag: String, delivery: Delivery ->
-            source.onNext(delivery)
-        }
-
-        consumerTag = channel.basicConsume(irohaQueue, autoAck, deliverCallback, { _ -> })
-
-        logger.info { "On subscribe to Iroha chain" }
-        return Result.of {
-            obs.map { delivery ->
-                val block = iroha.protocol.BlockOuterClass.Block.parseFrom(delivery.body)
-                logger.info { "New Iroha block arrived. Height ${block.blockV1.payload.height}" }
-                Pair(block, {
-                    if (!autoAck)
-                        channel.basicAck(delivery.envelope.deliveryTag, false)
-                })
-            }
-        }
-    }
-
-    /**
-     * @return a block as soon as it is committed to iroha
-     */
-    override suspend fun getBlock(autoAck: Boolean): Pair<iroha.protocol.BlockOuterClass.Block, () -> Unit> {
-        assertNotNull(rmqConfig)
-        assertNotNull(irohaQueue)
-
-        var resp: GetResponse?
-        do {
-            resp = channel.basicGet(irohaQueue, autoAck)
-        } while (resp == null)
-
-        val block = iroha.protocol.BlockOuterClass.Block.parseFrom(resp.body)
-        return Pair(block, {
-            if (!autoAck)
-                channel.basicAck(resp.envelope.deliveryTag, false)
-        })
-    }
-
-    fun purge() {
-        channel.queuePurge(irohaQueue)
+    override suspend fun getBlock(autoAck: Boolean): BlockOuterClass.Block {
+        return getBlockObservable().get().blockingFirst()
     }
 
     override fun close() {
         irohaAPI.close()
-        consumerTag?.let {
-            channel.basicCancel(it)
-        }
     }
 
     /**

--- a/notary-commons/src/main/kotlin/sidechain/iroha/ReliableIrohaChainListener.kt
+++ b/notary-commons/src/main/kotlin/sidechain/iroha/ReliableIrohaChainListener.kt
@@ -10,7 +10,6 @@ import io.reactivex.subjects.PublishSubject
 import jp.co.soramitsu.iroha.java.IrohaAPI
 import mu.KLogging
 import sidechain.ChainListener
-import kotlin.test.assertNotNull
 
 /**
  * Rabbit MQ based implementation of [ChainListener]
@@ -79,6 +78,7 @@ class ReliableIrohaChainListener(
     override suspend fun getBlock(autoAck: Boolean): Pair<iroha.protocol.BlockOuterClass.Block, () -> Unit> {
         var resp: GetResponse?
         do {
+            Thread.sleep(10L)
             resp = channel.basicGet(irohaQueue, autoAck)
         } while (resp == null)
 

--- a/notary-commons/src/main/kotlin/sidechain/iroha/ReliableIrohaChainListener.kt
+++ b/notary-commons/src/main/kotlin/sidechain/iroha/ReliableIrohaChainListener.kt
@@ -1,0 +1,107 @@
+package sidechain.iroha
+
+import com.github.kittinunf.result.Result
+import com.rabbitmq.client.ConnectionFactory
+import com.rabbitmq.client.Delivery
+import com.rabbitmq.client.GetResponse
+import config.RMQConfig
+import io.reactivex.Observable
+import io.reactivex.subjects.PublishSubject
+import jp.co.soramitsu.iroha.java.IrohaAPI
+import mu.KLogging
+import sidechain.ChainListener
+import kotlin.test.assertNotNull
+
+/**
+ * Rabbit MQ based implementation of [ChainListener]
+ */
+class ReliableIrohaChainListener(
+    private val irohaAPI: IrohaAPI,
+    private val rmqConfig: RMQConfig,
+    private val irohaQueue: String
+) : ChainListener<Pair<iroha.protocol.BlockOuterClass.Block, () -> Unit>> {
+
+    constructor(
+        irohaHost: String,
+        irohaPort: Int,
+        rmqConfig: RMQConfig,
+        irohaQueue: String
+    ) : this(IrohaAPI(irohaHost, irohaPort), rmqConfig, irohaQueue)
+
+    private val factory = ConnectionFactory()
+
+    private val conn by lazy {
+        factory.host = rmqConfig.host
+        factory.newConnection()
+    }
+
+    private val channel by lazy { conn.createChannel() }
+
+    private var consumerTag: String? = null
+
+    init {
+        channel.exchangeDeclare(rmqConfig.irohaExchange, "fanout", true)
+        channel.queueDeclare(irohaQueue, true, false, false, null)
+        channel.queueBind(irohaQueue, rmqConfig.irohaExchange, "")
+        channel.basicQos(1)
+    }
+
+
+    /**
+     * Returns an observable that emits a new block every time it gets it from Iroha
+     */
+    override fun getBlockObservable(autoAck: Boolean): Result<Observable<Pair<iroha.protocol.BlockOuterClass.Block, () -> Unit>>, Exception> {
+
+        val source = PublishSubject.create<Delivery>()
+        val obs: Observable<Delivery> = source
+        val deliverCallback = { consumerTag: String, delivery: Delivery ->
+            source.onNext(delivery)
+        }
+
+        consumerTag = channel.basicConsume(irohaQueue, autoAck, deliverCallback, { _ -> })
+
+        logger.info { "On subscribe to Iroha chain" }
+        return Result.of {
+            obs.map { delivery ->
+                val block = iroha.protocol.BlockOuterClass.Block.parseFrom(delivery.body)
+                logger.info { "New Iroha block arrived. Height ${block.blockV1.payload.height}" }
+                Pair(block, {
+                    if (!autoAck)
+                        channel.basicAck(delivery.envelope.deliveryTag, false)
+                })
+            }
+        }
+    }
+
+    /**
+     * @return a block as soon as it is committed to iroha
+     */
+    override suspend fun getBlock(autoAck: Boolean): Pair<iroha.protocol.BlockOuterClass.Block, () -> Unit> {
+        var resp: GetResponse?
+        do {
+            resp = channel.basicGet(irohaQueue, autoAck)
+        } while (resp == null)
+
+        val block = iroha.protocol.BlockOuterClass.Block.parseFrom(resp.body)
+        return Pair(block, {
+            if (!autoAck)
+                channel.basicAck(resp.envelope.deliveryTag, false)
+        })
+    }
+
+    fun purge() {
+        channel.queuePurge(irohaQueue)
+    }
+
+    override fun close() {
+        irohaAPI.close()
+        consumerTag?.let {
+            channel.basicCancel(it)
+        }
+    }
+
+    /**
+     * Logger
+     */
+    companion object : KLogging()
+}

--- a/notary-commons/src/main/kotlin/sidechain/iroha/ReliableIrohaChainListener.kt
+++ b/notary-commons/src/main/kotlin/sidechain/iroha/ReliableIrohaChainListener.kt
@@ -7,7 +7,6 @@ import com.rabbitmq.client.GetResponse
 import config.RMQConfig
 import io.reactivex.Observable
 import io.reactivex.subjects.PublishSubject
-import jp.co.soramitsu.iroha.java.IrohaAPI
 import mu.KLogging
 import sidechain.ChainListener
 
@@ -15,17 +14,9 @@ import sidechain.ChainListener
  * Rabbit MQ based implementation of [ChainListener]
  */
 class ReliableIrohaChainListener(
-    private val irohaAPI: IrohaAPI,
     private val rmqConfig: RMQConfig,
     private val irohaQueue: String
 ) : ChainListener<Pair<iroha.protocol.BlockOuterClass.Block, () -> Unit>> {
-
-    constructor(
-        irohaHost: String,
-        irohaPort: Int,
-        rmqConfig: RMQConfig,
-        irohaQueue: String
-    ) : this(IrohaAPI(irohaHost, irohaPort), rmqConfig, irohaQueue)
 
     private val factory = ConnectionFactory()
 
@@ -94,7 +85,6 @@ class ReliableIrohaChainListener(
     }
 
     override fun close() {
-        irohaAPI.close()
         consumerTag?.let {
             channel.basicCancel(it)
         }

--- a/notary-iroha-integration-test/src/integration-test/kotlin/integration/iroha/IrohaBatchTest.kt
+++ b/notary-iroha-integration-test/src/integration-test/kotlin/integration/iroha/IrohaBatchTest.kt
@@ -2,7 +2,6 @@ package integration.iroha
 
 import config.RMQConfig
 import config.getConfigFolder
-import config.loadConfigs
 import config.loadRawConfigs
 import integration.helper.IrohaConfigHelper
 import integration.helper.IrohaIntegrationHelperUtil
@@ -20,7 +19,7 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import sidechain.iroha.CLIENT_DOMAIN
-import sidechain.iroha.IrohaChainListener
+import sidechain.iroha.ReliableIrohaChainListener
 import sidechain.iroha.consumer.IrohaConsumerImpl
 import sidechain.iroha.consumer.IrohaConverter
 import sidechain.iroha.util.ModelUtil
@@ -51,10 +50,9 @@ class IrohaBatchTest {
 
     val assetDomain = "notary"
 
-    val listener = IrohaChainListener(
+    val listener = ReliableIrohaChainListener(
         testConfig.iroha.hostname,
         testConfig.iroha.port,
-        testCredential,
         rmqConfig,
         String.getRandomId()
     )
@@ -143,7 +141,7 @@ class IrohaBatchTest {
             val hashes = lst.map { String.hex(Utils.hash(it)) }
 
             val blockHashes = GlobalScope.async {
-                val(block, ack) = listener.getBlock()
+                val (block, ack) = listener.getBlock()
                 ack()
                 block.blockV1.payload.transactionsList.map {
                     String.hex(Utils.hash(it))
@@ -263,7 +261,7 @@ class IrohaBatchTest {
             val expectedHashes = hashes.subList(0, hashes.size - 1)
 
             val blockHashes = GlobalScope.async {
-                val(block, ack) = listener.getBlock()
+                val (block, ack) = listener.getBlock()
                 ack()
                 block.blockV1.payload.transactionsList.map {
                     String.hex(Utils.hash(it))

--- a/notary-iroha-integration-test/src/integration-test/kotlin/integration/iroha/IrohaBatchTest.kt
+++ b/notary-iroha-integration-test/src/integration-test/kotlin/integration/iroha/IrohaBatchTest.kt
@@ -51,8 +51,6 @@ class IrohaBatchTest {
     val assetDomain = "notary"
 
     val listener = ReliableIrohaChainListener(
-        testConfig.iroha.hostname,
-        testConfig.iroha.port,
         rmqConfig,
         String.getRandomId()
     )

--- a/notary-iroha-integration-test/src/integration-test/kotlin/integration/iroha/IrohaBlockStreamingTest.kt
+++ b/notary-iroha-integration-test/src/integration-test/kotlin/integration/iroha/IrohaBlockStreamingTest.kt
@@ -3,7 +3,6 @@ package integration.iroha
 import com.github.kittinunf.result.map
 import config.RMQConfig
 import config.getConfigFolder
-import config.loadConfigs
 import config.loadRawConfigs
 import integration.helper.IrohaConfigHelper
 import integration.helper.IrohaIntegrationHelperUtil
@@ -15,11 +14,10 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.assertEquals
-import sidechain.iroha.IrohaChainListener
+import sidechain.iroha.ReliableIrohaChainListener
 import sidechain.iroha.consumer.IrohaConsumerImpl
 import util.getRandomId
 import java.time.Duration
-import util.getRandomString
 
 /**
  * Note: Requires Iroha is running.
@@ -37,27 +35,27 @@ class IrohaBlockStreamingTest {
     private val creator = testCredential.accountId
 
     private val rmqConfig = loadRawConfigs("rmq", RMQConfig::class.java, "${getConfigFolder()}/rmq.properties")
-    lateinit private var listener : IrohaChainListener
+    lateinit private var listener: ReliableIrohaChainListener
 
     private val timeoutDuration = Duration.ofMinutes(IrohaConfigHelper.timeoutMinutes)
 
     @BeforeEach
     fun setUp() {
-        listener = IrohaChainListener(
+        listener = ReliableIrohaChainListener(
             testConfig.iroha.hostname,
             testConfig.iroha.port,
-            testCredential,
             rmqConfig,
             String.getRandomId()
         )
     }
+
     @AfterEach
     fun dropDown() {
         listener.close()
     }
 
     @AfterAll
-    fun tearDown(){
+    fun tearDown() {
         integrationHelper.close()
     }
 

--- a/notary-iroha-integration-test/src/integration-test/kotlin/integration/iroha/IrohaBlockStreamingTest.kt
+++ b/notary-iroha-integration-test/src/integration-test/kotlin/integration/iroha/IrohaBlockStreamingTest.kt
@@ -42,8 +42,6 @@ class IrohaBlockStreamingTest {
     @BeforeEach
     fun setUp() {
         listener = ReliableIrohaChainListener(
-            testConfig.iroha.hostname,
-            testConfig.iroha.port,
             rmqConfig,
             String.getRandomId()
         )

--- a/notary-iroha-integration-test/src/main/kotlin/integration/helper/IrohaIntegrationHelperUtil.kt
+++ b/notary-iroha-integration-test/src/main/kotlin/integration/helper/IrohaIntegrationHelperUtil.kt
@@ -68,8 +68,6 @@ open class IrohaIntegrationHelperUtil(private val peers: Int = 1) : Closeable {
 
     private val irohaChainListenerDelegate = lazy {
         ReliableIrohaChainListener(
-            testConfig.iroha.hostname,
-            testConfig.iroha.port,
             rmqConfig,
             testQueue
         )

--- a/notary-iroha-integration-test/src/main/kotlin/integration/helper/IrohaIntegrationHelperUtil.kt
+++ b/notary-iroha-integration-test/src/main/kotlin/integration/helper/IrohaIntegrationHelperUtil.kt
@@ -11,7 +11,7 @@ import jp.co.soramitsu.iroha.java.Transaction
 import kotlinx.coroutines.runBlocking
 import model.IrohaCredential
 import mu.KLogging
-import sidechain.iroha.IrohaChainListener
+import sidechain.iroha.ReliableIrohaChainListener
 import sidechain.iroha.consumer.IrohaConsumerImpl
 import sidechain.iroha.util.ModelUtil
 import sidechain.iroha.util.getAccountAsset
@@ -67,10 +67,9 @@ open class IrohaIntegrationHelperUtil(private val peers: Int = 1) : Closeable {
     val queryAPI by lazy { QueryAPI(irohaAPI, testCredential.accountId, testCredential.keyPair) }
 
     private val irohaChainListenerDelegate = lazy {
-        IrohaChainListener(
+        ReliableIrohaChainListener(
             testConfig.iroha.hostname,
             testConfig.iroha.port,
-            testCredential,
             rmqConfig,
             testQueue
         )

--- a/notifications-integration-test/src/integration-test/kotlin/notifications/environment/NotificationsIntegrationTestEnvironment.kt
+++ b/notifications-integration-test/src/integration-test/kotlin/notifications/environment/NotificationsIntegrationTestEnvironment.kt
@@ -1,5 +1,14 @@
 package notifications.environment
 
+import com.d3.notifications.config.PushAPIConfig
+import com.d3.notifications.config.SMTPConfig
+import com.d3.notifications.init.NotificationInitialization
+import com.d3.notifications.provider.D3ClientProvider
+import com.d3.notifications.push.PushServiceFactory
+import com.d3.notifications.push.WebPushAPIServiceImpl
+import com.d3.notifications.service.EmailNotificationService
+import com.d3.notifications.service.PushNotificationService
+import com.d3.notifications.smtp.SMTPServiceImpl
 import com.dumbster.smtp.SimpleSmtpServer
 import com.nhaarman.mockito_kotlin.spy
 import config.getConfigFolder
@@ -10,15 +19,6 @@ import jp.co.soramitsu.iroha.java.IrohaAPI
 import jp.co.soramitsu.iroha.java.QueryAPI
 import model.IrohaCredential
 import nl.martijndwars.webpush.PushService
-import com.d3.notifications.config.PushAPIConfig
-import com.d3.notifications.config.SMTPConfig
-import com.d3.notifications.init.NotificationInitialization
-import com.d3.notifications.provider.D3ClientProvider
-import com.d3.notifications.push.PushServiceFactory
-import com.d3.notifications.push.WebPushAPIServiceImpl
-import com.d3.notifications.service.EmailNotificationService
-import com.d3.notifications.service.PushNotificationService
-import com.d3.notifications.smtp.SMTPServiceImpl
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import sidechain.iroha.CLIENT_DOMAIN
 import sidechain.iroha.IrohaChainListener

--- a/notifications/src/main/kotlin/com/d3/notifications/config/NotificationAppConfiguration.kt
+++ b/notifications/src/main/kotlin/com/d3/notifications/config/NotificationAppConfiguration.kt
@@ -1,5 +1,8 @@
 package com.d3.notifications.config
 
+import com.d3.notifications.provider.D3ClientProvider
+import com.d3.notifications.push.PushServiceFactory
+import com.d3.notifications.smtp.SMTPServiceImpl
 import config.getConfigFolder
 import config.loadRawConfigs
 import io.grpc.ManagedChannelBuilder
@@ -7,9 +10,6 @@ import jp.co.soramitsu.iroha.java.IrohaAPI
 import jp.co.soramitsu.iroha.java.QueryAPI
 import model.IrohaCredential
 import nl.martijndwars.webpush.PushService
-import com.d3.notifications.provider.D3ClientProvider
-import com.d3.notifications.push.PushServiceFactory
-import com.d3.notifications.smtp.SMTPServiceImpl
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import sidechain.iroha.IrohaChainListener


### PR DESCRIPTION
### Description of change
Now Iroha chain listener is split into two: plain Iroha chain listener that listens to block directly from Iroha and reliable chain listener that listens to Rabbit MQ