### PR TITLE
Forgotten persistency mode

### DIFF
--- a/chain-adapter/src/main/kotlin/ChainAdapter.kt
+++ b/chain-adapter/src/main/kotlin/ChainAdapter.kt
@@ -2,6 +2,7 @@ package chainadapter
 
 import com.github.kittinunf.result.map
 import com.rabbitmq.client.ConnectionFactory
+import com.rabbitmq.client.MessageProperties
 import config.RMQConfig
 import jp.co.soramitsu.iroha.java.IrohaAPI
 import model.IrohaCredential
@@ -39,7 +40,12 @@ class ChainAdapter(private val rmqConfig: RMQConfig) {
                     logger.info { "Listening Iroha blocks" }
                     obs.blockingSubscribe {
                         val message = it.toByteArray()
-                        channel.basicPublish(rmqConfig.irohaExchange, "", null, message)
+                        channel.basicPublish(
+                            rmqConfig.irohaExchange,
+                            "",
+                            MessageProperties.MINIMAL_PERSISTENT_BASIC,
+                            message
+                        )
                         logger.info { "Block pushed" }
 
                     }


### PR DESCRIPTION
### Description of the Change
According to [AMQP documentation](https://www.rabbitmq.com/tutorials/amqp-concepts.html#queue-durability):

_**Durability of a queue does not make messages that are routed to that queue durable**. If broker is taken down and then brought back up, durable queue will be re-declared during broker startup, however, only persistent messages will be recovered.
Simply publishing a message to a durable exchange or the fact that the queue(s) it is routed to are durable **doesn't make a message persistent**: it all depends on persistence mode of the message itself._


So we need to set persistent mode for every message that goes to the exchange. We can do it using `MessageProperties.MINIMAL_PERSISTENT_BASIC`. 
