### PR TITLE
Configurable Reliable chain listener consumer thread pool

### DIFF
--- a/btc-dw-bridge/src/main/kotlin/com/d3/btc/dwbridge/config/BtcDWBridgeAppConfiguration.kt
+++ b/btc-dw-bridge/src/main/kotlin/com/d3/btc/dwbridge/config/BtcDWBridgeAppConfiguration.kt
@@ -130,7 +130,7 @@ class BtcDWBridgeAppConfiguration {
 
     @Bean
     fun withdrawalIrohaChainListener() = ReliableIrohaChainListener(
-        rmqConfig, withdrawalConfig.irohaBlockQueue
+        rmqConfig, withdrawalConfig.irohaBlockQueue, Executors.newSingleThreadExecutor()
     )
 
     @Bean

--- a/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/config/BtcWithdrawalAppConfiguration.kt
+++ b/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/config/BtcWithdrawalAppConfiguration.kt
@@ -96,7 +96,7 @@ class BtcWithdrawalAppConfiguration {
 
     @Bean
     fun withdrawalIrohaChainListener() = ReliableIrohaChainListener(
-        rmqConfig, withdrawalConfig.irohaBlockQueue
+        rmqConfig, withdrawalConfig.irohaBlockQueue, Executors.newSingleThreadExecutor()
     )
 
     @Bean

--- a/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/environment/BtcWithdrawalTestEnvironment.kt
+++ b/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/environment/BtcWithdrawalTestEnvironment.kt
@@ -59,7 +59,7 @@ class BtcWithdrawalTestEnvironment(
      */
     private val executor = Executors.newSingleThreadExecutor()
 
-    private val rmqConfig = loadRawConfigs("rmq", RMQConfig::class.java, "${getConfigFolder()}/rmq.properties") 
+    private val rmqConfig = loadRawConfigs("rmq", RMQConfig::class.java, "${getConfigFolder()}/rmq.properties")
 
     private val irohaApi by lazy {
         val irohaAPI = IrohaAPI(
@@ -105,7 +105,8 @@ class BtcWithdrawalTestEnvironment(
 
     private val irohaChainListener = ReliableIrohaChainListener(
         rmqConfig,
-        testName
+        testName,
+        Executors.newSingleThreadExecutor()
     )
 
     val btcRegisteredAddressesProvider = BtcRegisteredAddressesProvider(


### PR DESCRIPTION
### Description of the Change
By default, RabbitMQ delivery callback will be executed in the thread pool that is created using the 
following code:

`this.executor = (executor == null) ? Executors.newFixedThreadPool(DEFAULT_NUM_THREADS, threadFactory)`

If no executor is specified, fixed thread pool is used. But sometimes it's useful to specify custom consumer thread pool. Especially in `btc-withdrawal-service`, where we assume that every transfer is handled one-by-one in a sequential fashion.

