### PR TITLE
fix chain-adapter depends on rmq

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -79,6 +79,8 @@ services:
   d3-chain-adapter:
     image: nexus.iroha.tech:19002/d3-deploy/chain-adapter:${TAG-master}
     container_name: d3-chain-adapter
+    depends_on:
+      - d3-rmq
     volumes:
       - ./:/opt/notary/deploy
       - ../configs:/opt/notary/configs


### PR DESCRIPTION
Signed-off-by: Alexey Chernyshov <alexey.n.chernyshov@gmail.com>

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * Jenkins builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->


### Description of the Change
Add dependency to chain-adapter on RMQ in docker-compose.

### Usage Examples or Tests *[optional]*

