### PR TITLE
add docker-wait-for d3-rmq

### DIFF
--- a/deploy/docker-compose-base.yml
+++ b/deploy/docker-compose-base.yml
@@ -42,10 +42,16 @@ services:
   d3-chain-adapter:
     image: nexus.iroha.tech:19002/d3-deploy/chain-adapter:${TAG-master}
     container_name: d3-chain-adapter
+    depends_on:
+      - d3-rmq
+      - d3-iroha
     volumes:
       - ./:/opt/notary/deploy
       - ../configs:/opt/notary/configs
     environment:
+      - WAIT_HOSTS=d3-iroha:50051, d3-rmq:5672
+      - WAIT_HOSTS_TIMEOUT=300
+      - WAIT_SLEEP_INTERVAL=3
       - PROFILE
       - IROHA_HOST=d3-iroha
       - IROHA_PORT=50051
@@ -57,7 +63,5 @@ services:
 volumes:
   iroha_block_store:
 
-
 networks:
   d3-network:
-

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -80,11 +80,15 @@ services:
     image: nexus.iroha.tech:19002/d3-deploy/chain-adapter:${TAG-master}
     container_name: d3-chain-adapter
     depends_on:
+      - d3-iroha
       - d3-rmq
     volumes:
       - ./:/opt/notary/deploy
       - ../configs:/opt/notary/configs
     environment:
+      - WAIT_HOSTS=d3-iroha:50051, d3-rmq:5672
+      - WAIT_HOSTS_TIMEOUT=300
+      - WAIT_SLEEP_INTERVAL=3
       - PROFILE
       - IROHA_HOST=d3-iroha
       - IROHA_PORT=50051

--- a/docker/chain-adapter.dockerfile
+++ b/docker/chain-adapter.dockerfile
@@ -7,6 +7,10 @@ COPY chain-adapter/build/libs/chain-adapter-all.jar /opt/notary/chain-adapter.ja
 # Please run `kscript --package grpc_healthcheck.kts` before building docker image
 COPY grpc_healthcheck /opt/notary
 
+## Wait for script (see https://github.com/ufoscout/docker-compose-wait/)
+ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.5.0/wait /opt/notary/wait
+RUN chmod +x /opt/notary/wait
+
 COPY docker/entrypoint.sh /opt/notary/
 RUN chmod +x /opt/notary/entrypoint.sh
-ENTRYPOINT ["/opt/notary/entrypoint.sh"]
+ENTRYPOINT /opt/notary/wait && /opt/notary/entrypoint.sh


### PR DESCRIPTION
<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * Jenkins builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->


### Description of the Change
Add wait for d3-rmq and d3-iroha on chain-adapter startup

### Usage Examples or Tests *[optional]*

