### PR TITLE
Named thread pools

### DIFF
--- a/btc-address-generation/src/main/kotlin/com/d3/btc/generation/config/BtcAddressGenerationAppConfiguration.kt
+++ b/btc-address-generation/src/main/kotlin/com/d3/btc/generation/config/BtcAddressGenerationAppConfiguration.kt
@@ -1,18 +1,21 @@
 package com.d3.btc.generation.config
 
+import com.d3.btc.generation.BTC_ADDRESS_GENERATION_SERVICE_NAME
 import com.d3.commons.config.loadConfigs
-import io.grpc.ManagedChannelBuilder
-import jp.co.soramitsu.iroha.java.IrohaAPI
-import jp.co.soramitsu.iroha.java.QueryAPI
 import com.d3.commons.model.IrohaCredential
-import org.bitcoinj.wallet.Wallet
-import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.Configuration
 import com.d3.commons.provider.NotaryPeerListProvider
 import com.d3.commons.provider.NotaryPeerListProviderImpl
 import com.d3.commons.sidechain.iroha.IrohaChainListener
 import com.d3.commons.sidechain.iroha.consumer.IrohaConsumerImpl
 import com.d3.commons.sidechain.iroha.util.ModelUtil
+import com.d3.commons.util.createPrettySingleThreadPool
+import com.d3.commons.util.namedThreadFactory
+import io.grpc.ManagedChannelBuilder
+import jp.co.soramitsu.iroha.java.IrohaAPI
+import jp.co.soramitsu.iroha.java.QueryAPI
+import org.bitcoinj.wallet.Wallet
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import java.io.File
 import java.util.concurrent.Executors
 
@@ -62,7 +65,12 @@ class BtcAddressGenerationAppConfiguration {
             ManagedChannelBuilder.forAddress(
                 btcAddressGenerationConfig.iroha.hostname,
                 btcAddressGenerationConfig.iroha.port
-            ).executor(Executors.newSingleThreadExecutor()).usePlaintext().build()
+            ).executor(
+                createPrettySingleThreadPool(
+                    BTC_ADDRESS_GENERATION_SERVICE_NAME,
+                    "iroha-chain-listener"
+                )
+            ).usePlaintext().build()
         )
         return irohaAPI
     }

--- a/btc-address-generation/src/main/kotlin/com/d3/btc/generation/main.kt
+++ b/btc-address-generation/src/main/kotlin/com/d3/btc/generation/main.kt
@@ -11,6 +11,8 @@ import mu.KLogging
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.annotation.ComponentScan
 
+const val BTC_ADDRESS_GENERATION_SERVICE_NAME = "btc-add-gen"
+
 @ComponentScan(
     basePackages = [
         "com.d3.btc.generation",

--- a/btc-deposit/src/main/kotlin/com/d3/btc/deposit/config/BtcNotaryAppConfiguration.kt
+++ b/btc-deposit/src/main/kotlin/com/d3/btc/deposit/config/BtcNotaryAppConfiguration.kt
@@ -1,16 +1,18 @@
 package com.d3.btc.deposit.config
 
+import com.d3.btc.deposit.BTC_DEPOSIT_SERVICE_NAME
 import com.d3.btc.provider.BtcRegisteredAddressesProvider
 import com.d3.commons.config.BitcoinConfig
 import com.d3.commons.config.loadConfigs
+import com.d3.commons.model.IrohaCredential
+import com.d3.commons.sidechain.iroha.IrohaChainListener
+import com.d3.commons.sidechain.iroha.util.ModelUtil
+import com.d3.commons.util.createPrettySingleThreadPool
 import jp.co.soramitsu.iroha.java.IrohaAPI
 import jp.co.soramitsu.iroha.java.QueryAPI
-import com.d3.commons.model.IrohaCredential
 import org.bitcoinj.wallet.Wallet
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import com.d3.commons.sidechain.iroha.IrohaChainListener
-import com.d3.commons.sidechain.iroha.util.ModelUtil
 import java.io.File
 
 val depositConfig = loadConfigs("btc-deposit", BtcDepositConfig::class.java, "/btc/deposit.properties").get()
@@ -50,6 +52,10 @@ class BtcNotaryAppConfiguration {
                 )
             }, { ex -> throw ex })
     }
+
+    @Bean
+    fun registeredClientsListenerExecutor() =
+        createPrettySingleThreadPool(BTC_DEPOSIT_SERVICE_NAME, "reg-clients-listener")
 
     @Bean
     fun transferWallet() = Wallet.loadFromFile(File(depositConfig.btcTransferWalletPath))

--- a/btc-deposit/src/main/kotlin/com/d3/btc/deposit/main.kt
+++ b/btc-deposit/src/main/kotlin/com/d3/btc/deposit/main.kt
@@ -12,6 +12,8 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.EnableMBeanExport
 
+const val BTC_DEPOSIT_SERVICE_NAME="btc-deposit"
+
 @EnableMBeanExport
 @ComponentScan(
     basePackages = [

--- a/btc-dw-bridge/src/main/kotlin/com/d3/btc/dwbridge/main.kt
+++ b/btc-dw-bridge/src/main/kotlin/com/d3/btc/dwbridge/main.kt
@@ -17,6 +17,8 @@ import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.EnableMBeanExport
 import com.d3.commons.util.createFolderIfDoesntExist
 
+const val BTC_DW_BRIDGE_SERVICE_NAME = "btc-dw-bridge"
+
 @EnableMBeanExport
 @ComponentScan(
     basePackages = [

--- a/btc-registration/src/main/kotlin/com/d3/btc/registration/main.kt
+++ b/btc-registration/src/main/kotlin/com/d3/btc/registration/main.kt
@@ -12,6 +12,7 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.annotation.ComponentScan
 
 private val logger = KLogging().logger
+const val BTC_REGISTRATION_SERVICE_NAME="btc-registration"
 
 @ComponentScan(basePackages = ["com.d3.btc.registration"])
 class BtcRegistrationApplication

--- a/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/config/BtcWithdrawalAppConfiguration.kt
+++ b/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/config/BtcWithdrawalAppConfiguration.kt
@@ -2,6 +2,7 @@ package com.d3.btc.withdrawal.config
 
 import com.d3.btc.fee.BtcFeeRateService
 import com.d3.btc.provider.BtcRegisteredAddressesProvider
+import com.d3.btc.withdrawal.BTC_WITHDRAWAL_SERVICE_NAME
 import com.d3.btc.withdrawal.provider.BtcChangeAddressProvider
 import com.d3.btc.withdrawal.provider.BtcWhiteListProvider
 import com.d3.btc.withdrawal.statistics.WithdrawalStatistics
@@ -10,6 +11,7 @@ import com.d3.commons.model.IrohaCredential
 import com.d3.commons.provider.NotaryPeerListProviderImpl
 import com.d3.commons.sidechain.iroha.consumer.IrohaConsumerImpl
 import com.d3.commons.sidechain.iroha.util.ModelUtil
+import com.d3.commons.util.createPrettySingleThreadPool
 import io.grpc.ManagedChannelBuilder
 import jp.co.soramitsu.iroha.java.IrohaAPI
 import jp.co.soramitsu.iroha.java.QueryAPI
@@ -94,7 +96,12 @@ class BtcWithdrawalAppConfiguration {
             ManagedChannelBuilder.forAddress(
                 withdrawalConfig.iroha.hostname,
                 withdrawalConfig.iroha.port
-            ).executor(Executors.newSingleThreadExecutor()).usePlaintext().build()
+            ).executor(
+                createPrettySingleThreadPool(
+                    BTC_WITHDRAWAL_SERVICE_NAME,
+                    "iroha-chain-listener"
+                )
+            ).usePlaintext().build()
         )
         return irohaAPI
     }

--- a/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/listener/BitcoinFeeRateListener.kt
+++ b/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/listener/BitcoinFeeRateListener.kt
@@ -16,6 +16,7 @@ private const val DAY_MILLIS = 24 * 60 * 60 * 1000L
 private const val INIT_TIME_FEE_RATE_UPDATE_DELAY_MIN = 1
 private const val FEE_RATE_UPDATE_DELAY_MIN = 5
 
+//TODO this class must be removed. It makes no sense anymore.
 /**
  * This listener listens to fee rate changes
  */

--- a/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/main.kt
+++ b/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/main.kt
@@ -12,6 +12,8 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.EnableMBeanExport
 
+const val BTC_WITHDRAWAL_SERVICE_NAME = "btc-withdrawal"
+
 @EnableMBeanExport
 @ComponentScan(
     basePackages = [

--- a/chain-adapter-integration-test/src/integration-test/kotlin/integration/chainadapter/environment/ChainAdapterIntegrationTestEnvironment.kt
+++ b/chain-adapter-integration-test/src/integration-test/kotlin/integration/chainadapter/environment/ChainAdapterIntegrationTestEnvironment.kt
@@ -1,10 +1,12 @@
 package integration.chainadapter.environment
 
+import com.d3.chainadapter.CHAIN_ADAPTER_SERVICE_NAME
 import com.d3.chainadapter.adapter.ChainAdapter
 import com.d3.chainadapter.provider.FileBasedLastReadBlockProvider
 import com.d3.commons.model.IrohaCredential
 import com.d3.commons.sidechain.iroha.IrohaChainListener
 import com.d3.commons.sidechain.iroha.util.ModelUtil
+import com.d3.commons.util.createPrettySingleThreadPool
 import com.d3.commons.util.getRandomString
 import integration.helper.ChainAdapterConfigHelper
 import integration.helper.IrohaIntegrationHelperUtil
@@ -13,7 +15,6 @@ import iroha.protocol.Commands
 import jp.co.soramitsu.iroha.java.IrohaAPI
 import jp.co.soramitsu.iroha.java.QueryAPI
 import java.io.Closeable
-import java.util.concurrent.Executors
 
 /**
  * Chain adapter test environment
@@ -31,7 +32,7 @@ class ChainAdapterIntegrationTestEnvironment : Closeable {
         integrationTestHelper.accountHelper.irohaConsumer
     }
 
-    val consumerExecutorService = Executors.newSingleThreadExecutor()
+    val consumerExecutorService = createPrettySingleThreadPool(CHAIN_ADAPTER_SERVICE_NAME, "iroha-blocks-consumer")
 
     private val chainAdapterConfigHelper = ChainAdapterConfigHelper()
 
@@ -50,7 +51,12 @@ class ChainAdapterIntegrationTestEnvironment : Closeable {
         irohaAPI.setChannelForStreamingQueryStub(
             ManagedChannelBuilder.forAddress(
                 rmqConfig.iroha.hostname, rmqConfig.iroha.port
-            ).executor(Executors.newSingleThreadExecutor()).usePlaintext().build()
+            ).executor(
+                createPrettySingleThreadPool(
+                    CHAIN_ADAPTER_SERVICE_NAME,
+                    "iroha-chain-listener"
+                )
+            ).usePlaintext().build()
         )
     }
 

--- a/chain-adapter/src/main/kotlin/com/d3/chainadapter/adapter/ChainAdapter.kt
+++ b/chain-adapter/src/main/kotlin/com/d3/chainadapter/adapter/ChainAdapter.kt
@@ -1,10 +1,12 @@
 package com.d3.chainadapter.adapter
 
+import com.d3.chainadapter.CHAIN_ADAPTER_SERVICE_NAME
 import com.d3.chainadapter.provider.LastReadBlockProvider
 import com.d3.commons.config.RMQConfig
 import com.d3.commons.sidechain.iroha.IrohaChainListener
 import com.d3.commons.sidechain.iroha.util.getBlockRawResponse
 import com.d3.commons.sidechain.iroha.util.getErrorMessage
+import com.d3.commons.util.createPrettySingleThreadPool
 import com.github.kittinunf.result.Result
 import com.github.kittinunf.result.map
 import com.rabbitmq.client.Channel
@@ -17,7 +19,6 @@ import jp.co.soramitsu.iroha.java.QueryAPI
 import mu.KLogging
 import java.io.Closeable
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicLong
 
 private const val BAD_IROHA_BLOCK_HEIGHT_ERROR_CODE = 3
@@ -36,7 +37,9 @@ class ChainAdapter(
     private val connectionFactory = ConnectionFactory()
     private val lastReadBlock = AtomicLong()
     private val publishUnreadLatch = CountDownLatch(1)
-    private val subscriberExecutorService = Executors.newSingleThreadExecutor()
+    private val subscriberExecutorService = createPrettySingleThreadPool(
+        CHAIN_ADAPTER_SERVICE_NAME, "iroha-chain-subscriber"
+    )
 
     init {
         connectionFactory.host = rmqConfig.host

--- a/chain-adapter/src/main/kotlin/com/d3/chainadapter/main.kt
+++ b/chain-adapter/src/main/kotlin/com/d3/chainadapter/main.kt
@@ -10,6 +10,7 @@ import com.d3.commons.config.loadRawConfigs
 import com.d3.commons.model.IrohaCredential
 import com.d3.commons.sidechain.iroha.IrohaChainListener
 import com.d3.commons.sidechain.iroha.util.ModelUtil
+import com.d3.commons.util.createPrettySingleThreadPool
 import com.github.kittinunf.result.failure
 import com.github.kittinunf.result.map
 import io.grpc.ManagedChannelBuilder
@@ -18,9 +19,9 @@ import jp.co.soramitsu.iroha.java.QueryAPI
 import mu.KLogging
 import java.io.File
 import java.io.IOException
-import java.util.concurrent.Executors
 
 private val logger = KLogging().logger
+const val CHAIN_ADAPTER_SERVICE_NAME = "chain-adapter"
 
 //TODO Springify
 fun main(args: Array<String>) {
@@ -37,7 +38,12 @@ fun main(args: Array<String>) {
         irohaAPI.setChannelForStreamingQueryStub(
             ManagedChannelBuilder.forAddress(
                 rmqConfig.iroha.hostname, rmqConfig.iroha.port
-            ).executor(Executors.newSingleThreadExecutor()).usePlaintext().build()
+            ).executor(
+                createPrettySingleThreadPool(
+                    CHAIN_ADAPTER_SERVICE_NAME,
+                    "iroha-chain-listener"
+                )
+            ).usePlaintext().build()
         )
         val queryAPI =
             QueryAPI(

--- a/eth-registration/src/main/kotlin/com/d3/eth/registration/EthRegistrationStrategyImpl.kt
+++ b/eth-registration/src/main/kotlin/com/d3/eth/registration/EthRegistrationStrategyImpl.kt
@@ -15,6 +15,8 @@ import com.d3.commons.registration.IrohaEthAccountCreator
 import com.d3.commons.registration.RegistrationStrategy
 import com.d3.eth.sidechain.util.BasicAuthenticator
 import com.d3.commons.sidechain.iroha.consumer.IrohaConsumer
+import com.d3.commons.util.createPrettyScheduledThreadPool
+import org.web3j.protocol.core.JsonRpc2_0Web3j
 import java.math.BigInteger
 
 /**
@@ -41,7 +43,11 @@ class EthRegistrationStrategyImpl(
             passwordConfig
         )
     )!!
-    private val web3 = Web3j.build(HttpService(ethRegistrationConfig.ethereum.url, builder.build(), false))!!
+    private val web3 = Web3j.build(
+        HttpService(ethRegistrationConfig.ethereum.url, builder.build(), false),
+        JsonRpc2_0Web3j.DEFAULT_BLOCK_TIME.toLong(),
+        createPrettyScheduledThreadPool(ETH_REGISTRATION_SERVICE_NAME, "web3j")
+    )
 
     private val relayRegistry = RelayRegistry.load(
         ethRegistrationConfig.ethRelayRegistryAddress,

--- a/eth-registration/src/main/kotlin/com/d3/eth/registration/main.kt
+++ b/eth-registration/src/main/kotlin/com/d3/eth/registration/main.kt
@@ -14,6 +14,8 @@ import mu.KLogging
 
 private val logger = KLogging().logger
 
+const val ETH_REGISTRATION_SERVICE_NAME = "eth-registration"
+
 /**
  * Entry point for Registration Service
  */

--- a/eth-withdrawal/src/main/kotlin/com/d3/eth/withdrawal/withdrawalservice/main.kt
+++ b/eth-withdrawal/src/main/kotlin/com/d3/eth/withdrawal/withdrawalservice/main.kt
@@ -2,20 +2,22 @@
 
 package com.d3.eth.withdrawal.withdrawalservice
 
+import com.d3.commons.config.*
+import com.d3.commons.model.IrohaCredential
+import com.d3.commons.sidechain.iroha.util.ModelUtil
+import com.d3.eth.vacuum.RelayVacuumConfig
 import com.github.kittinunf.result.failure
 import com.github.kittinunf.result.fanout
 import com.github.kittinunf.result.flatMap
 import com.github.kittinunf.result.map
-import com.d3.commons.config.*
 import jp.co.soramitsu.iroha.java.IrohaAPI
-import com.d3.commons.model.IrohaCredential
 import mu.KLogging
-import com.d3.commons.sidechain.iroha.util.ModelUtil
-import com.d3.eth.vacuum.RelayVacuumConfig
 
 private val logger = KLogging().logger
 
 private const val RELAY_VACUUM_PREFIX = "relay-vacuum"
+
+const val ETH_WITHDRAWAL_SERVICE_NAME = "eth-withdrawal"
 
 /**
  * Main entry point of Withdrawal Service app

--- a/eth/src/main/kotlin/com/d3/eth/deposit/EthDepositInitialization.kt
+++ b/eth/src/main/kotlin/com/d3/eth/deposit/EthDepositInitialization.kt
@@ -23,9 +23,11 @@ import com.d3.commons.provider.NotaryPeerListProviderImpl
 import com.d3.eth.provider.EthRelayProvider
 import com.d3.eth.provider.EthTokensProvider
 import com.d3.commons.sidechain.SideChainEvent
+import com.d3.commons.util.createPrettyScheduledThreadPool
 import com.d3.eth.sidechain.EthChainHandler
 import com.d3.eth.sidechain.EthChainListener
 import com.d3.eth.sidechain.util.BasicAuthenticator
+import org.web3j.protocol.core.JsonRpc2_0Web3j
 import java.math.BigInteger
 
 const val ENDPOINT_ETHEREUM = "eth"
@@ -65,7 +67,11 @@ class EthDepositInitialization(
 
         val builder = OkHttpClient().newBuilder()
         builder.authenticator(BasicAuthenticator(passwordsConfig))
-        val web3 = Web3j.build(HttpService(ethDepositConfig.ethereum.url, builder.build(), false))
+        val web3 = Web3j.build(
+            HttpService(ethDepositConfig.ethereum.url, builder.build(), false),
+            JsonRpc2_0Web3j.DEFAULT_BLOCK_TIME.toLong(),
+            createPrettyScheduledThreadPool(ETH_DEPOSIT_SERVICE_NAME, "web3j")
+        )
 
         /** List of all observable wallets */
         val ethHandler = EthChainHandler(web3, ethRelayProvider, ethTokensProvider)

--- a/eth/src/main/kotlin/com/d3/eth/deposit/main.kt
+++ b/eth/src/main/kotlin/com/d3/eth/deposit/main.kt
@@ -16,6 +16,8 @@ import mu.KLogging
 
 private val logger = KLogging().logger
 
+const val ETH_DEPOSIT_SERVICE_NAME = "eth-deposit"
+
 /**
  * Application entry point
  */

--- a/eth/src/main/kotlin/com/d3/eth/sidechain/util/DeployHelper.kt
+++ b/eth/src/main/kotlin/com/d3/eth/sidechain/util/DeployHelper.kt
@@ -2,6 +2,7 @@ package com.d3.eth.sidechain.util
 
 import com.d3.commons.config.EthereumConfig
 import com.d3.commons.config.EthereumPasswords
+import com.d3.commons.util.createPrettyScheduledThreadPool
 import contract.*
 import com.d3.eth.helper.encodeFunction
 import mu.KLogging
@@ -12,6 +13,7 @@ import org.web3j.abi.datatypes.Type
 import org.web3j.crypto.WalletUtils
 import org.web3j.protocol.Web3j
 import org.web3j.protocol.core.DefaultBlockParameterName
+import org.web3j.protocol.core.JsonRpc2_0Web3j.DEFAULT_BLOCK_TIME
 import org.web3j.protocol.http.HttpService
 import org.web3j.tx.RawTransactionManager
 import org.web3j.tx.Transfer
@@ -42,7 +44,10 @@ class DeployHelper(ethereumConfig: EthereumConfig, ethereumPasswords: EthereumPa
     init {
         val builder = OkHttpClient().newBuilder()
         builder.authenticator(BasicAuthenticator(ethereumPasswords))
-        web3 = Web3j.build(HttpService(ethereumConfig.url, builder.build(), false))
+        web3 = Web3j.build(
+            HttpService(ethereumConfig.url, builder.build(), false), DEFAULT_BLOCK_TIME.toLong(),
+            createPrettyScheduledThreadPool(DeployHelper::class.simpleName!!, "web3j")
+        )
     }
 
     /** credentials of ethereum user */

--- a/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/BtcFullPipelineTest.kt
+++ b/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/BtcFullPipelineTest.kt
@@ -169,10 +169,10 @@ class BtcFullPipelineTest {
 
         // Send 1 BTC multiple times
         val sendBtcThreads = ArrayList<Thread>()
-        for (deposit in 1..totalTransfers) {
-            val sendBtcThread = Thread {
+        for (transfer in 1..totalTransfers) {
+            val sendBtcThread = Thread({
                 integrationHelper.sendBtc(srcBtcAddress, 1, 0)
-            }
+            }, "transfer-thread-$transfer")
             sendBtcThreads.add(sendBtcThread)
             sendBtcThread.start()
         }

--- a/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/BtcMultiNotaryIntegrationTest.kt
+++ b/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/BtcMultiNotaryIntegrationTest.kt
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import java.io.File
 import java.math.BigDecimal
 
-
 @Disabled
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class BtcMultiNotaryIntegrationTest {

--- a/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/environment/BtcAddressGenerationTestEnvironment.kt
+++ b/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/environment/BtcAddressGenerationTestEnvironment.kt
@@ -1,5 +1,6 @@
 package integration.btc.environment
 
+import com.d3.btc.generation.BTC_ADDRESS_GENERATION_SERVICE_NAME
 import com.d3.btc.generation.config.BtcAddressGenerationConfig
 import com.d3.btc.generation.init.BtcAddressGenerationInitialization
 import com.d3.btc.generation.trigger.AddressGenerationTrigger
@@ -9,20 +10,20 @@ import com.d3.btc.provider.address.BtcAddressesProvider
 import com.d3.btc.provider.generation.BtcPublicKeyProvider
 import com.d3.btc.provider.generation.BtcSessionProvider
 import com.d3.btc.provider.network.BtcRegTestConfigProvider
-import integration.helper.BtcIntegrationHelperUtil
-import io.grpc.ManagedChannelBuilder
-import jp.co.soramitsu.iroha.java.IrohaAPI
-import jp.co.soramitsu.iroha.java.QueryAPI
 import com.d3.commons.model.IrohaCredential
-import org.bitcoinj.wallet.Wallet
 import com.d3.commons.provider.NotaryPeerListProviderImpl
 import com.d3.commons.provider.TriggerProvider
 import com.d3.commons.sidechain.iroha.IrohaChainListener
 import com.d3.commons.sidechain.iroha.consumer.IrohaConsumerImpl
 import com.d3.commons.sidechain.iroha.util.ModelUtil
+import com.d3.commons.util.createPrettySingleThreadPool
+import integration.helper.BtcIntegrationHelperUtil
+import io.grpc.ManagedChannelBuilder
+import jp.co.soramitsu.iroha.java.IrohaAPI
+import jp.co.soramitsu.iroha.java.QueryAPI
+import org.bitcoinj.wallet.Wallet
 import java.io.Closeable
 import java.io.File
-import java.util.concurrent.Executors
 
 //How many addresses to generate at initial phase
 private const val INIT_ADDRESSES = 3
@@ -49,7 +50,7 @@ class BtcAddressGenerationTestEnvironment(
      * It's essential to handle blocks in this service one-by-one.
      * This is why we explicitly set single threaded executor.
      */
-    private val executor = Executors.newSingleThreadExecutor()
+    private val executor = createPrettySingleThreadPool(BTC_ADDRESS_GENERATION_SERVICE_NAME, "iroha-chain-listener")
 
     private val irohaApi by lazy {
         val irohaAPI = IrohaAPI(

--- a/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/environment/BtcNotaryTestEnvironment.kt
+++ b/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/environment/BtcNotaryTestEnvironment.kt
@@ -1,5 +1,6 @@
 package integration.btc.environment
 
+import com.d3.btc.deposit.BTC_DEPOSIT_SERVICE_NAME
 import com.d3.btc.deposit.config.BtcDepositConfig
 import com.d3.btc.deposit.init.BtcNotaryInitialization
 import com.d3.btc.handler.NewBtcClientRegistrationHandler
@@ -7,10 +8,11 @@ import com.d3.btc.listener.NewBtcClientRegistrationListener
 import com.d3.btc.provider.BtcRegisteredAddressesProvider
 import com.d3.btc.provider.network.BtcRegTestConfigProvider
 import com.d3.commons.config.BitcoinConfig
-import integration.helper.BtcIntegrationHelperUtil
 import com.d3.commons.model.IrohaCredential
 import com.d3.commons.sidechain.iroha.IrohaChainListener
 import com.d3.commons.sidechain.iroha.util.ModelUtil
+import com.d3.commons.util.createPrettySingleThreadPool
+import integration.helper.BtcIntegrationHelperUtil
 import java.io.Closeable
 import java.io.File
 
@@ -45,7 +47,10 @@ class BtcNotaryTestEnvironment(
     )
 
     private val newBtcClientRegistrationListener =
-        NewBtcClientRegistrationListener(NewBtcClientRegistrationHandler(btcNetworkConfigProvider))
+        NewBtcClientRegistrationListener(
+            NewBtcClientRegistrationHandler(btcNetworkConfigProvider),
+            createPrettySingleThreadPool(BTC_DEPOSIT_SERVICE_NAME, "reg-clients-listener")
+        )
 
     private val transferWallet = org.bitcoinj.wallet.Wallet.loadFromFile(File(notaryConfig.btcTransferWalletPath))
 

--- a/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/environment/BtcWithdrawalTestEnvironment.kt
+++ b/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/environment/BtcWithdrawalTestEnvironment.kt
@@ -6,6 +6,7 @@ import com.d3.btc.helper.address.outPutToBase58Address
 import com.d3.btc.provider.BtcRegisteredAddressesProvider
 import com.d3.btc.provider.network.BtcNetworkConfigProvider
 import com.d3.btc.provider.network.BtcRegTestConfigProvider
+import com.d3.btc.withdrawal.BTC_WITHDRAWAL_SERVICE_NAME
 import com.d3.btc.withdrawal.config.BtcWithdrawalConfig
 import com.d3.btc.withdrawal.handler.NewFeeRateWasSetHandler
 import com.d3.btc.withdrawal.handler.NewSignatureEventHandler
@@ -23,6 +24,7 @@ import com.d3.commons.model.IrohaCredential
 import com.d3.commons.provider.NotaryPeerListProviderImpl
 import com.d3.commons.sidechain.iroha.consumer.IrohaConsumerImpl
 import com.d3.commons.sidechain.iroha.util.ModelUtil
+import com.d3.commons.util.createPrettySingleThreadPool
 import com.rabbitmq.client.ConnectionFactory
 import integration.helper.BtcIntegrationHelperUtil
 import io.grpc.ManagedChannelBuilder
@@ -57,7 +59,7 @@ class BtcWithdrawalTestEnvironment(
      * It's essential to handle blocks in this service one-by-one.
      * This is why we explicitly set single threaded executor.
      */
-    private val executor = Executors.newSingleThreadExecutor()
+    private val executor = createPrettySingleThreadPool(BTC_WITHDRAWAL_SERVICE_NAME, "iroha-chain-listener")
 
     val rmqConfig = loadRawConfigs("rmq", RMQConfig::class.java, "${getConfigFolder()}/rmq.properties")
 

--- a/notary-commons/src/main/kotlin/com/d3/commons/notary/NotaryImpl.kt
+++ b/notary-commons/src/main/kotlin/com/d3/commons/notary/NotaryImpl.kt
@@ -1,17 +1,17 @@
 package com.d3.commons.notary
 
-import com.github.kittinunf.result.Result
-import io.reactivex.Observable
-import io.reactivex.schedulers.Schedulers
-import jp.co.soramitsu.iroha.java.IrohaAPI
 import com.d3.commons.model.IrohaCredential
-import mu.KLogging
 import com.d3.commons.provider.NotaryPeerListProvider
 import com.d3.commons.sidechain.SideChainEvent
 import com.d3.commons.sidechain.iroha.consumer.IrohaConsumerImpl
 import com.d3.commons.sidechain.iroha.consumer.IrohaConverter
+import com.d3.commons.util.createPrettySingleThreadPool
+import com.github.kittinunf.result.Result
+import io.reactivex.Observable
+import io.reactivex.schedulers.Schedulers
+import jp.co.soramitsu.iroha.java.IrohaAPI
+import mu.KLogging
 import java.math.BigInteger
-import java.util.concurrent.Executors
 
 /**
  * Implementation of [Notary] business logic
@@ -118,7 +118,7 @@ class NotaryImpl(
             // Init Iroha Consumer pipeline
             irohaOutput()
                 // convert from Notary model to Iroha model
-                .subscribeOn(Schedulers.from(Executors.newSingleThreadExecutor()))
+                .subscribeOn(Schedulers.from(createPrettySingleThreadPool("notary", "iroha-consumer")))
                 .subscribe(
                     // send to Iroha network layer
                     { batch ->

--- a/notary-commons/src/main/kotlin/com/d3/commons/sidechain/iroha/ReliableIrohaChainListener.kt
+++ b/notary-commons/src/main/kotlin/com/d3/commons/sidechain/iroha/ReliableIrohaChainListener.kt
@@ -35,6 +35,13 @@ class ReliableIrohaChainListener(
         irohaQueue: String
     ) : this(rmqConfig, irohaQueue, { _, _ -> }, null, true)
 
+    constructor(
+        rmqConfig: RMQConfig,
+        irohaQueue: String,
+        consumerExecutorService: ExecutorService
+    ) : this(rmqConfig, irohaQueue, { _, _ -> }, consumerExecutorService, true)
+
+
     private val factory = ConnectionFactory()
 
     // Last read Iroha block number. Used to detect double read.

--- a/notary-commons/src/main/kotlin/com/d3/commons/util/ThreadUtil.kt
+++ b/notary-commons/src/main/kotlin/com/d3/commons/util/ThreadUtil.kt
@@ -11,7 +11,7 @@ private val log = KLogging().logger
 
 /**
  * Creates thread factory that may be used in thread pool.
- * Format is [serviceName-purpose-th-(thread number)-id-(thread id)]
+ * Format is [serviceName:purpose:th-(thread number):id-(thread id)]
  * @param serviceName - name of service (withdrawal, deposit and etc)
  * @param purpose - purpose of thread (Iroha listener, Ethereum tx listener and etc)
  * @return thread factory
@@ -24,7 +24,7 @@ fun namedThreadFactory(
         private val threadCounter = AtomicInteger(0)
         override fun newThread(runnable: Runnable): Thread {
             val thread = Executors.defaultThreadFactory().newThread(runnable)
-            thread.name = "$serviceName-$purpose-th-${threadCounter.getAndIncrement()}-id-${thread.id}"
+            thread.name = "$serviceName:$purpose:th-${threadCounter.getAndIncrement()}:id-${thread.id}"
             return thread
         }
     }

--- a/notary-commons/src/main/kotlin/com/d3/commons/util/ThreadUtil.kt
+++ b/notary-commons/src/main/kotlin/com/d3/commons/util/ThreadUtil.kt
@@ -1,0 +1,77 @@
+package com.d3.commons.util
+
+import mu.KLogging
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ThreadFactory
+import java.util.concurrent.atomic.AtomicInteger
+
+private val log = KLogging().logger
+
+/**
+ * Creates thread factory that may be used in thread pool.
+ * Format is [serviceName-purpose-th-(thread number)-id-(thread id)]
+ * @param serviceName - name of service (withdrawal, deposit and etc)
+ * @param purpose - purpose of thread (Iroha listener, Ethereum tx listener and etc)
+ * @return thread factory
+ */
+fun namedThreadFactory(
+    serviceName: String,
+    purpose: String
+): ThreadFactory {
+    return object : ThreadFactory {
+        private val threadCounter = AtomicInteger(0)
+        override fun newThread(runnable: Runnable): Thread {
+            val thread = Executors.defaultThreadFactory().newThread(runnable)
+            thread.name = "$serviceName-$purpose-th-${threadCounter.getAndIncrement()}-id-${thread.id}"
+            return thread
+        }
+    }
+}
+
+/**
+ * Creates pretty named single threaded pool
+ * @param serviceName - name of service (withdrawal, deposit and etc)
+ * @param purpose - purpose of thread (Iroha listener, Ethereum tx listener and etc)
+ * @return pretty thread pool
+ */
+fun createPrettySingleThreadPool(
+    serviceName: String,
+    purpose: String
+): ExecutorService {
+    return Executors.newSingleThreadExecutor(namedThreadFactory(serviceName, purpose))!!
+}
+
+/**
+ * Creates pretty named fixed thread pool
+ * @param serviceName - name of service (withdrawal, deposit and etc)
+ * @param purpose - purpose of thread (Iroha listener, Ethereum tx listener and etc)
+ * @return pretty thread pool
+ */
+fun createPrettyFixThreadPool(
+    serviceName: String,
+    purpose: String
+): ExecutorService {
+    return Executors.newFixedThreadPool(
+        Runtime.getRuntime().availableProcessors(),
+        namedThreadFactory(serviceName, purpose)
+    )!!
+}
+
+/**
+ * Creates pretty named scheduled thread pool
+ * @param serviceName - name of service (withdrawal, deposit and etc)
+ * @param purpose - purpose of thread (Iroha listener, Ethereum tx listener and etc)
+ * @return pretty thread pool
+ */
+fun createPrettyScheduledThreadPool(
+    serviceName: String,
+    purpose: String
+): ScheduledExecutorService {
+    return Executors.newScheduledThreadPool(
+        Runtime.getRuntime().availableProcessors(),
+        namedThreadFactory(serviceName, purpose)
+    )!!
+}
+

--- a/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/DepositIntegrationTest.kt
+++ b/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/DepositIntegrationTest.kt
@@ -60,6 +60,7 @@ class DepositIntegrationTest {
     @Test
     fun depositOfETH() {
         Assertions.assertTimeoutPreemptively(timeoutDuration) {
+            integrationHelper.nameCurrentThread(this::class.simpleName!!)
             val initialAmount = integrationHelper.getIrohaAccountBalance(clientIrohaAccountId, etherAssetId)
             val amount = BigInteger.valueOf(1_234_000_000_000)
             // send ETH
@@ -87,6 +88,7 @@ class DepositIntegrationTest {
     @Test
     fun depositZeroETH() {
         Assertions.assertTimeoutPreemptively(timeoutDuration) {
+            Thread.currentThread().name = this::class.simpleName
             val initialAmount = integrationHelper.getIrohaAccountBalance(clientIrohaAccountId, etherAssetId)
             val zeroAmount = BigInteger.ZERO
             val amount = BigInteger.valueOf(1_234_000_000_000)
@@ -123,6 +125,7 @@ class DepositIntegrationTest {
     @Test
     fun depositOfERC20() {
         Assertions.assertTimeoutPreemptively(timeoutDuration) {
+            Thread.currentThread().name = this::class.simpleName
             val (tokenInfo, tokenAddress) = integrationHelper.deployRandomERC20Token(2)
             val assetId = "${tokenInfo.name}#ethereum"
             val initialAmount = integrationHelper.getIrohaAccountBalance(clientIrohaAccountId, assetId)
@@ -151,6 +154,7 @@ class DepositIntegrationTest {
     @Test
     fun depositZeroOfERC20() {
         Assertions.assertTimeoutPreemptively(timeoutDuration) {
+            Thread.currentThread().name = this::class.simpleName
             val (tokenInfo, tokenAddress) = integrationHelper.deployRandomERC20Token(2)
             val assetId = "${tokenInfo.name}#ethereum"
             val initialAmount = integrationHelper.getIrohaAccountBalance(clientIrohaAccountId, assetId)

--- a/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/DepositMultiIntegrationTest.kt
+++ b/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/DepositMultiIntegrationTest.kt
@@ -96,6 +96,7 @@ class DepositMultiIntegrationTest {
     @Test
     fun depositMultisig() {
         Assertions.assertTimeoutPreemptively(timeoutDuration) {
+            Thread.currentThread().name = this::class.simpleName
             val initialAmount = integrationHelper.getIrohaAccountBalance(clientIrohaAccountId, etherAssetId)
             val amount = BigInteger.valueOf(1_234_000_000_000)
             // send ETH
@@ -122,6 +123,7 @@ class DepositMultiIntegrationTest {
     @Test
     fun depositMultisigERC20() {
         Assertions.assertTimeoutPreemptively(timeoutDuration) {
+            integrationHelper.nameCurrentThread(this::class.simpleName!!)
             val (tokenInfo, tokenAddress) = integrationHelper.deployRandomERC20Token(2)
             val assetId = "${tokenInfo.name}#ethereum"
             val initialAmount = integrationHelper.getIrohaAccountBalance(clientIrohaAccountId, assetId)

--- a/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/ERC20TokenRegistrationTest.kt
+++ b/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/ERC20TokenRegistrationTest.kt
@@ -56,6 +56,7 @@ class ERC20TokenRegistrationTest {
     @Test
     fun testTokenRegistration() {
         assertTimeoutPreemptively(timeoutDuration) {
+            integrationHelper.nameCurrentThread(this::class.simpleName!!)
             val tokens = createRandomTokens()
             createTokensFile(tokens, tokensFilePath)
             executeTokenRegistration(tokenRegistrationConfig)
@@ -98,6 +99,7 @@ class ERC20TokenRegistrationTest {
     @Test
     fun testTokenRegistrationEmptyTokenFile() {
         assertTimeoutPreemptively(timeoutDuration) {
+            integrationHelper.nameCurrentThread(this::class.simpleName!!)
             createTokensFile(HashMap(), tokensFilePath)
             executeTokenRegistration(tokenRegistrationConfig)
             ethTokensProvider.getTokens().fold({ tokensFromProvider ->

--- a/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/EthFreeRelayProviderTest.kt
+++ b/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/EthFreeRelayProviderTest.kt
@@ -43,6 +43,7 @@ class EthFreeRelayProviderTest {
     @Test
     fun getFreeWallet() {
         assertTimeoutPreemptively(timeoutDuration) {
+            integrationHelper.nameCurrentThread(this::class.simpleName!!)
             val ethFreeWallet = "eth_free_wallet_stub"
 
             setAccountDetail(
@@ -88,6 +89,7 @@ class EthFreeRelayProviderTest {
     @Test
     fun testStorageFromFile() {
         assertTimeoutPreemptively(timeoutDuration) {
+            integrationHelper.nameCurrentThread(this::class.simpleName!!)
             val relayHolder = File.createTempFile("relay", "free")
             relayHolder.deleteOnExit()
             val existingRelays = setOf(

--- a/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/EthRelayProviderIrohaTest.kt
+++ b/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/EthRelayProviderIrohaTest.kt
@@ -1,5 +1,6 @@
 package integration.eth
 
+import com.d3.eth.provider.EthRelayProviderIrohaImpl
 import integration.helper.EthIntegrationHelperUtil
 import integration.helper.IrohaConfigHelper
 import org.junit.jupiter.api.AfterAll
@@ -8,7 +9,6 @@ import org.junit.jupiter.api.Assertions.assertTimeoutPreemptively
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.fail
-import com.d3.eth.provider.EthRelayProviderIrohaImpl
 import java.time.Duration
 
 /**
@@ -18,8 +18,6 @@ import java.time.Duration
 class EthRelayProviderIrohaTest {
 
     val integrationHelper = EthIntegrationHelperUtil()
-
-    val testConfig = integrationHelper.configHelper.testConfig
 
     /** Iroha account that holds details */
     private val relayStorage = integrationHelper.accountHelper.notaryAccount.accountId
@@ -42,6 +40,7 @@ class EthRelayProviderIrohaTest {
     @Test
     fun testStorage() {
         assertTimeoutPreemptively(timeoutDuration) {
+            integrationHelper.nameCurrentThread(this::class.simpleName!!)
             val domain = "notary"
 
             val entries = mapOf(
@@ -77,6 +76,7 @@ class EthRelayProviderIrohaTest {
     @Test
     fun testEmptyStorage() {
         assertTimeoutPreemptively(timeoutDuration) {
+            integrationHelper.nameCurrentThread(this::class.simpleName!!)
             EthRelayProviderIrohaImpl(
                 integrationHelper.queryAPI,
                 integrationHelper.testCredential.accountId,

--- a/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/EthTokensProviderTest.kt
+++ b/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/EthTokensProviderTest.kt
@@ -42,6 +42,7 @@ class EthTokensProviderTest {
     @Test
     fun testGetTokens() {
         assertTimeoutPreemptively(timeoutDuration) {
+            integrationHelper.nameCurrentThread(this::class.simpleName!!)
             val tokensToAdd = 3
             val expectedTokens = mutableMapOf<String, EthTokenInfo>()
             (1..tokensToAdd).forEach { precision ->
@@ -76,6 +77,7 @@ class EthTokensProviderTest {
     @Test
     fun getNonexistentToken() {
         assertTimeoutPreemptively(timeoutDuration) {
+            integrationHelper.nameCurrentThread(this::class.simpleName!!)
             ethTokensProvider.getTokenPrecision("nonexist")
                 .fold(
                     { fail("Result returned success while failure is expected.") },
@@ -99,6 +101,7 @@ class EthTokensProviderTest {
     @Test
     fun getEthereum() {
         assertTimeoutPreemptively(timeoutDuration) {
+            integrationHelper.nameCurrentThread(this::class.simpleName!!)
             ethTokensProvider.getTokenPrecision("$ETH_NAME#$ETH_DOMAIN")
                 .success { assertEquals(ETH_PRECISION, it) }
 

--- a/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/FailedTransactionTest.kt
+++ b/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/FailedTransactionTest.kt
@@ -41,6 +41,7 @@ class FailedTransactionTest {
     @Test
     fun failedEtherTransferTest() {
         Assertions.assertTimeoutPreemptively(timeoutDuration) {
+            integrationHelper.nameCurrentThread(this::class.simpleName!!)
             val failerAddress = integrationHelper.deployFailer()
             integrationHelper.registerRelayByAddress(failerAddress)
             val clientAccount = String.getRandomString(9)
@@ -65,6 +66,7 @@ class FailedTransactionTest {
     @Test
     fun failedTokenTransferTest() {
         Assertions.assertTimeoutPreemptively(timeoutDuration) {
+            integrationHelper.nameCurrentThread(this::class.simpleName!!)
             val failerAddress = integrationHelper.deployFailer()
             val anotherFailerAddress = integrationHelper.deployFailer()
             integrationHelper.registerRelayByAddress(failerAddress)

--- a/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/VacuumIntegrationTest.kt
+++ b/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/VacuumIntegrationTest.kt
@@ -4,10 +4,7 @@ import com.d3.eth.vacuum.executeVacuum
 import integration.helper.EthIntegrationHelperUtil
 import integration.helper.IrohaConfigHelper
 import mu.KLogging
-import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.Assertions
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.*
 import java.math.BigInteger
 import java.time.Duration
 
@@ -36,6 +33,7 @@ class VacuumIntegrationTest {
     @Test
     fun testVacuum() {
         Assertions.assertTimeoutPreemptively(timeoutDuration) {
+            integrationHelper.nameCurrentThread(this::class.simpleName!!)
             deployFewTokens()
             integrationHelper.deployRelays(2)
             integrationHelper.registerRandomRelay()

--- a/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/WithdrawalIntegrationTest.kt
+++ b/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/WithdrawalIntegrationTest.kt
@@ -62,6 +62,7 @@ class WithdrawalIntegrationTest {
     @Test
     fun testRefund() {
         assertTimeoutPreemptively(timeoutDuration) {
+            integrationHelper.nameCurrentThread(this::class.simpleName!!)
             val masterAccount = depositConfig.notaryCredential.accountId
             val amount = "64203"
             val decimalAmount = BigDecimal(amount).scaleByPowerOfTen(ETH_PRECISION)

--- a/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/WithdrawalMultinotaryIntegrationTest.kt
+++ b/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/WithdrawalMultinotaryIntegrationTest.kt
@@ -93,6 +93,7 @@ class WithdrawalMultinotaryIntegrationTest {
     @Test
     fun testRefund() {
         Assertions.assertTimeoutPreemptively(timeoutDuration) {
+            integrationHelper.nameCurrentThread(this::class.simpleName!!)
             val masterAccount = integrationHelper.accountHelper.notaryAccount.accountId
             val amount = "64203"
             val decimalAmount = BigDecimal(amount).scaleByPowerOfTen(ETH_PRECISION)

--- a/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/WithdrawalPipelineIntegrationTest.kt
+++ b/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/WithdrawalPipelineIntegrationTest.kt
@@ -1,16 +1,16 @@
 package integration.eth
 
+import com.d3.commons.sidechain.iroha.CLIENT_DOMAIN
+import com.d3.commons.sidechain.iroha.util.ModelUtil
+import com.d3.commons.util.getRandomString
+import com.d3.commons.util.toHexString
+import com.d3.eth.provider.ETH_PRECISION
 import integration.helper.EthIntegrationHelperUtil
 import integration.helper.IrohaConfigHelper
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import org.junit.jupiter.api.*
-import com.d3.eth.provider.ETH_PRECISION
-import com.d3.commons.sidechain.iroha.CLIENT_DOMAIN
-import com.d3.commons.sidechain.iroha.util.ModelUtil
-import com.d3.commons.util.getRandomString
-import com.d3.commons.util.toHexString
 import java.math.BigDecimal
 import java.math.BigInteger
 import java.security.KeyPair
@@ -85,6 +85,7 @@ class WithdrawalPipelineIntegrationTest {
     @Test
     fun testFullWithdrawalPipeline() {
         Assertions.assertTimeoutPreemptively(timeoutDuration) {
+            integrationHelper.nameCurrentThread(this::class.simpleName!!)
             val amount = BigInteger.valueOf(1251400000000)
 
             // deploy free relay
@@ -137,6 +138,7 @@ class WithdrawalPipelineIntegrationTest {
     @Test
     fun testFullWithdrawalPipelineErc20() {
         Assertions.assertTimeoutPreemptively(timeoutDuration) {
+            integrationHelper.nameCurrentThread(this::class.simpleName!!)
             val precision = 2
 
             // deploy free relay
@@ -197,6 +199,7 @@ class WithdrawalPipelineIntegrationTest {
     @Test
     fun testWithdrawInWhitelist() {
         Assertions.assertTimeoutPreemptively(timeoutDuration) {
+            integrationHelper.nameCurrentThread(this::class.simpleName!!)
             integrationHelper.registerClient(clientName, listOf(toAddress, "0x123"), keypair)
 
             val amount = BigDecimal(125)
@@ -235,6 +238,7 @@ class WithdrawalPipelineIntegrationTest {
     @Test
     fun testWithdrawEmptyWhitelist() {
         Assertions.assertTimeoutPreemptively(timeoutDuration) {
+            integrationHelper.nameCurrentThread(this::class.simpleName!!)
             // TODO: D3-417 Web3j cannot pass an empty list of addresses to the smart contract.
             integrationHelper.registerClient(clientName, listOf(), keypair)
 
@@ -275,6 +279,7 @@ class WithdrawalPipelineIntegrationTest {
     @Test
     fun testWithdrawNotInWhitelist() {
         Assertions.assertTimeoutPreemptively(timeoutDuration) {
+            integrationHelper.nameCurrentThread(this::class.simpleName!!)
             integrationHelper.registerClient(clientName, listOf("0x123"), keypair)
             integrationHelper.setWhitelist(clientId, listOf("0x123"))
 

--- a/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/WithdrawalRollbackIntegrationTest.kt
+++ b/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/WithdrawalRollbackIntegrationTest.kt
@@ -1,15 +1,15 @@
 package integration.eth
 
+import com.d3.commons.sidechain.iroha.CLIENT_DOMAIN
+import com.d3.commons.sidechain.iroha.util.ModelUtil
+import com.d3.commons.util.getRandomString
+import com.d3.commons.util.toHexString
+import com.d3.eth.provider.ETH_PRECISION
 import integration.helper.EthIntegrationHelperUtil
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import org.junit.jupiter.api.*
-import com.d3.eth.provider.ETH_PRECISION
-import com.d3.commons.sidechain.iroha.CLIENT_DOMAIN
-import com.d3.commons.sidechain.iroha.util.ModelUtil
-import com.d3.commons.util.getRandomString
-import com.d3.commons.util.toHexString
 import java.math.BigDecimal
 import java.math.BigInteger
 import java.security.KeyPair

--- a/notary-iroha-integration-test/src/integration-test/kotlin/integration/iroha/IrohaBlockStreamingTest.kt
+++ b/notary-iroha-integration-test/src/integration-test/kotlin/integration/iroha/IrohaBlockStreamingTest.kt
@@ -1,9 +1,13 @@
 package integration.iroha
 
-import com.github.kittinunf.result.map
 import com.d3.commons.config.RMQConfig
 import com.d3.commons.config.getConfigFolder
 import com.d3.commons.config.loadRawConfigs
+import com.d3.commons.sidechain.iroha.ReliableIrohaChainListener
+import com.d3.commons.sidechain.iroha.consumer.IrohaConsumerImpl
+import com.d3.commons.util.createPrettyFixThreadPool
+import com.d3.commons.util.getRandomId
+import com.github.kittinunf.result.map
 import integration.helper.IrohaConfigHelper
 import integration.helper.IrohaIntegrationHelperUtil
 import io.reactivex.schedulers.Schedulers
@@ -14,9 +18,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.assertEquals
-import com.d3.commons.sidechain.iroha.ReliableIrohaChainListener
-import com.d3.commons.sidechain.iroha.consumer.IrohaConsumerImpl
-import com.d3.commons.util.getRandomId
 import java.time.Duration
 
 /**
@@ -73,7 +74,11 @@ class IrohaBlockStreamingTest {
                             .flatMap {
                                 it.payload.reducedPayload.commandsList
                             }
-                    }.subscribeOn(Schedulers.io()).subscribe()
+                    }.subscribeOn(
+                        Schedulers.from(
+                            createPrettyFixThreadPool("iroha-block-streaming", "test")
+                        )
+                    ).subscribe()
                 }
 
             val utx = Transaction.builder(creator)

--- a/notary-iroha-integration-test/src/main/kotlin/integration/helper/IrohaIntegrationHelperUtil.kt
+++ b/notary-iroha-integration-test/src/main/kotlin/integration/helper/IrohaIntegrationHelperUtil.kt
@@ -4,18 +4,18 @@ import com.d3.commons.config.RMQConfig
 import com.d3.commons.config.getConfigFolder
 import com.d3.commons.config.loadConfigs
 import com.d3.commons.config.loadRawConfigs
-import integration.TestConfig
-import jp.co.soramitsu.iroha.java.IrohaAPI
-import jp.co.soramitsu.iroha.java.QueryAPI
-import jp.co.soramitsu.iroha.java.Transaction
-import kotlinx.coroutines.runBlocking
 import com.d3.commons.model.IrohaCredential
-import mu.KLogging
 import com.d3.commons.sidechain.iroha.ReliableIrohaChainListener
 import com.d3.commons.sidechain.iroha.consumer.IrohaConsumerImpl
 import com.d3.commons.sidechain.iroha.util.ModelUtil
 import com.d3.commons.sidechain.iroha.util.getAccountAsset
 import com.d3.commons.util.getRandomString
+import integration.TestConfig
+import jp.co.soramitsu.iroha.java.IrohaAPI
+import jp.co.soramitsu.iroha.java.QueryAPI
+import jp.co.soramitsu.iroha.java.Transaction
+import kotlinx.coroutines.runBlocking
+import mu.KLogging
 import java.io.Closeable
 import java.math.BigDecimal
 import java.security.KeyPair
@@ -111,6 +111,14 @@ open class IrohaIntegrationHelperUtil(private val peers: Int = 1) : Closeable {
             queryAPI,
             account
         ).get().toString()
+    }
+
+    /**
+     * Names current thread
+     * @param name - name of thread
+     */
+    fun nameCurrentThread(name: String) {
+        Thread.currentThread().name = name
     }
 
     /**

--- a/notifications/src/main/kotlin/com/d3/notifications/main.kt
+++ b/notifications/src/main/kotlin/com/d3/notifications/main.kt
@@ -10,6 +10,8 @@ import mu.KLogging
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.annotation.ComponentScan
 
+const val NOTIFICATIONS_SERVICE_NAME="notifications"
+
 @ComponentScan(basePackages = ["com.d3.notifications"])
 class NotificationApplication
 


### PR DESCRIPTION
### Description of the Change
Now all the thread pools are properly named. Format is: `[service_name:purpose:thread_num:thread_id]`
For example:
```
[13.03.2019 14:44:43,494] btc-integration-tests [WARN ] [main] No profile set. Using default local profile
[13.03.2019 13:53:13,984] eth-integration-tests [INFO ] [eth-deposit:web3j:th-0:id-27] Handle Ethereum tx 0x65b33337519c034607414e4ecbf4ba9aabb3449e19b1e50105000e63cc9578cf
[13.03.2019 14:43:26,828] eth-integration-tests [INFO ] [eth-withdrawal:rmq-consumer:th-0:id-33] New Iroha block from RMQ arrived. Height 410
[13.03.2019 14:45:10,139] btc-integration-tests [INFO ] [btc-add-gen:iroha-chain-listener:th-0:id-24] New Iroha block arrived. Height 427
[13.03.2019 15:40:05,366] chain-adapter [INFO ] [chain-adapter:iroha-chain-listener:th-0:id-23] New Iroha block arrived. Height 462
```