### PR TITLE
Restart unconfirmed transactions

### DIFF
--- a/btc-deposit/src/main/kotlin/com/d3/btc/deposit/handler/BtcDepositTxHandler.kt
+++ b/btc-deposit/src/main/kotlin/com/d3/btc/deposit/handler/BtcDepositTxHandler.kt
@@ -1,0 +1,70 @@
+package com.d3.btc.deposit.handler
+
+import com.d3.btc.helper.address.outPutToBase58Address
+import com.d3.btc.helper.currency.satToBtc
+import com.d3.btc.model.BtcAddress
+import com.d3.commons.sidechain.SideChainEvent
+import io.reactivex.subjects.PublishSubject
+import mu.KLogging
+import org.bitcoinj.core.Transaction
+import java.math.BigInteger
+import java.util.*
+
+private const val BTC_ASSET_NAME = "btc"
+private const val BTC_ASSET_DOMAIN = "bitcoin"
+private const val TWO_HOURS_MILLIS = 2 * 60 * 60 * 1000L
+
+/**
+ * Handler of Bitcoin deposit transactions
+ * @param registeredAddresses - registered addresses. Used to get Bitcoin address data
+ * @param btcEventsSource - source of Bitcoin deposit events
+ * @param onTxSave - function that is called to save transaction in wallet
+ */
+class BtcDepositTxHandler(
+    private val registeredAddresses: List<BtcAddress>,
+    private val btcEventsSource: PublishSubject<SideChainEvent.PrimaryBlockChainEvent>,
+    private val onTxSave: () -> Unit
+) {
+
+    /**
+     * Handles deposit transaction
+     * @param tx - Bitcoin deposit transaction
+     * @param blockTime - time of block where [tx] appeared for the first time. This time is used in MST
+     */
+    fun handleTx(tx: Transaction, blockTime: Date) {
+        tx.outputs.forEach { output ->
+            val txBtcAddress = outPutToBase58Address(output)
+            logger.info { "Tx ${tx.hashAsString} has output address $txBtcAddress" }
+            val btcAddress = registeredAddresses.firstOrNull { btcAddress -> btcAddress.address == txBtcAddress }
+            if (btcAddress != null) {
+                val btcValue = satToBtc(output.value.value)
+                val event = SideChainEvent.PrimaryBlockChainEvent.OnPrimaryChainDeposit(
+                    tx.hashAsString,
+                    /*
+                    Due to Iroha time restrictions, tx time must be in range [current time - 1 day; current time + 5 min],
+                    while Bitcoin block time must be in range [median time of last 11 blocks; network time + 2 hours].
+                    Given these restrictions, block time may be more than 5 minutes ahead of current time.
+                    Subtracting 2 hours is just a simple workaround of this problem.
+                    */
+                    BigInteger.valueOf(blockTime.time - TWO_HOURS_MILLIS),
+                    btcAddress.info.irohaClient!!,
+                    "$BTC_ASSET_NAME#$BTC_ASSET_DOMAIN",
+                    btcValue.toPlainString(),
+                    ""
+                )
+                logger.info {
+                    "BTC deposit event(tx ${tx.hashAsString}, amount ${btcValue.toPlainString()}) was created. " +
+                            "Related client is ${btcAddress.info.irohaClient}. "
+                }
+                btcEventsSource.onNext(event)
+                //TODO better call this function after event consumption.
+                onTxSave()
+            }
+        }
+    }
+
+    /**
+     * Logger
+     */
+    companion object : KLogging()
+}

--- a/btc-deposit/src/main/kotlin/com/d3/btc/deposit/init/BtcNotaryInitialization.kt
+++ b/btc-deposit/src/main/kotlin/com/d3/btc/deposit/init/BtcNotaryInitialization.kt
@@ -3,26 +3,23 @@ package com.d3.btc.deposit.init
 import com.d3.btc.deposit.BTC_DEPOSIT_SERVICE_NAME
 import com.d3.btc.deposit.config.BtcDepositConfig
 import com.d3.btc.deposit.listener.BitcoinBlockChainDepositListener
+import com.d3.btc.deposit.service.BtcWalletListenerRestartService
 import com.d3.btc.healthcheck.HealthyService
 import com.d3.btc.helper.network.addPeerConnectionStatusListener
 import com.d3.btc.helper.network.startChainDownload
 import com.d3.btc.listener.NewBtcClientRegistrationListener
+import com.d3.btc.peer.SharedPeerGroup
 import com.d3.btc.provider.BtcRegisteredAddressesProvider
 import com.d3.btc.provider.network.BtcNetworkConfigProvider
-import com.d3.commons.model.IrohaCredential
 import com.d3.commons.notary.NotaryImpl
-import com.d3.commons.provider.NotaryPeerListProviderImpl
 import com.d3.commons.sidechain.SideChainEvent
 import com.d3.commons.sidechain.iroha.IrohaChainListener
 import com.d3.commons.util.createPrettySingleThreadPool
-import com.d3.commons.util.namedThreadFactory
 import com.github.kittinunf.result.Result
 import com.github.kittinunf.result.failure
 import com.github.kittinunf.result.flatMap
 import com.github.kittinunf.result.map
-import io.reactivex.Observable
-import jp.co.soramitsu.iroha.java.IrohaAPI
-import jp.co.soramitsu.iroha.java.QueryAPI
+import io.reactivex.subjects.PublishSubject
 import mu.KLogging
 import org.bitcoinj.core.Address
 import org.bitcoinj.core.PeerGroup
@@ -33,32 +30,34 @@ import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
 import java.io.Closeable
 import java.io.File
-import java.util.concurrent.Executors
+import java.util.concurrent.ExecutorService
 
 @Component
 class BtcNotaryInitialization(
-    @Autowired private val peerGroup: PeerGroup,
+    @Autowired private val peerGroup: SharedPeerGroup,
     @Autowired private val transferWallet: Wallet,
     @Autowired private val btcDepositConfig: BtcDepositConfig,
-    @Qualifier("notaryCredential")
-    @Autowired private val irohaCredential: IrohaCredential,
-    @Autowired private val irohaAPI: IrohaAPI,
+    @Autowired private val notary: NotaryImpl,
     @Autowired private val btcRegisteredAddressesProvider: BtcRegisteredAddressesProvider,
+    @Autowired private val btcEventsSource: PublishSubject<SideChainEvent.PrimaryBlockChainEvent>,
     @Qualifier("depositIrohaChainListener")
     @Autowired private val irohaChainListener: IrohaChainListener,
     @Autowired private val newBtcClientRegistrationListener: NewBtcClientRegistrationListener,
+    @Autowired private val btcWalletListenerRestartService: BtcWalletListenerRestartService,
+    @Qualifier("confidenceListenerExecutorService")
+    @Autowired private val confidenceListenerExecutorService: ExecutorService,
     @Autowired private val btcNetworkConfigProvider: BtcNetworkConfigProvider
 ) : HealthyService(), Closeable {
-
 
     // Executor that will be used to execute Bitcoin deposit listener logic
     private val blockChainDepositListenerExecutor =
         createPrettySingleThreadPool(BTC_DEPOSIT_SERVICE_NAME, "blockchain-deposit-listener")
 
-
-    // Executor that will be used to execute transaction confidence listener logic
-    private val confidenceListenerExecutorService =
-        createPrettySingleThreadPool(BTC_DEPOSIT_SERVICE_NAME, "tx-confidence-listener")
+    // Function that is called to save all the transactions in wallet
+    private fun onTxSave() {
+        transferWallet.saveToFile(File(btcDepositConfig.btcTransferWalletPath))
+        logger.info { "Wallet was saved in ${btcDepositConfig.btcTransferWalletPath}" }
+    }
 
     /**
      * Init notary
@@ -68,7 +67,12 @@ class BtcNotaryInitialization(
         //Enables short log format for Bitcoin events
         BriefLogFormatter.init()
         addPeerConnectionStatusListener(peerGroup, ::notHealthy, ::cured)
-        return irohaChainListener.getBlockObservable().map { irohaObservable ->
+        // Restart wallet listeners
+        return btcWalletListenerRestartService.restartTransactionListeners(
+            transferWallet, ::onTxSave
+        ).flatMap {
+            irohaChainListener.getBlockObservable()
+        }.map { irohaObservable ->
             newBtcClientRegistrationListener.listenToRegisteredClients(
                 transferWallet, irohaObservable
             ) {
@@ -90,16 +94,8 @@ class BtcNotaryInitialization(
             }
             logger.info { "Previously registered addresses were added to the transferWallet" }
         }.map {
-            getBtcEvents(peerGroup, btcDepositConfig.bitcoin.confidenceLevel)
-        }.map { btcEvents ->
-            val queryAPI = QueryAPI(irohaAPI, irohaCredential.accountId, irohaCredential.keyPair)
-
-            val peerListProvider = NotaryPeerListProviderImpl(
-                queryAPI,
-                btcDepositConfig.notaryListStorageAccount,
-                btcDepositConfig.notaryListSetterAccount
-            )
-            val notary = NotaryImpl(irohaCredential, irohaAPI, btcEvents, peerListProvider)
+            initBtcEvents(peerGroup, btcDepositConfig.bitcoin.confidenceLevel)
+        }.map {
             notary.initIrohaConsumer().failure { ex -> throw ex }
         }.map {
             startChainDownload(peerGroup)
@@ -111,28 +107,26 @@ class BtcNotaryInitialization(
         transferWallet.isAddressWatched(Address.fromBase58(btcNetworkConfigProvider.getConfig(), btcAddress))
 
     /**
-     * Returns observable object full of deposit events
+     * Initiates Btc deposit events
      */
-    private fun getBtcEvents(
+    private fun initBtcEvents(
         peerGroup: PeerGroup,
         confidenceLevel: Int
-    ): Observable<SideChainEvent.PrimaryBlockChainEvent> {
-        return Observable.create<SideChainEvent.PrimaryBlockChainEvent> { emitter ->
-            peerGroup.addBlocksDownloadedEventListener(
-                blockChainDepositListenerExecutor,
-                BitcoinBlockChainDepositListener(
-                    btcRegisteredAddressesProvider,
-                    emitter,
-                    confidenceListenerExecutorService,
-                    confidenceLevel
-                ) { transferWallet.saveToFile(File(btcDepositConfig.btcTransferWalletPath)) }
+    ) {
+        peerGroup.addBlocksDownloadedEventListener(
+            blockChainDepositListenerExecutor,
+            BitcoinBlockChainDepositListener(
+                btcRegisteredAddressesProvider,
+                btcEventsSource,
+                confidenceListenerExecutorService,
+                confidenceLevel,
+                ::onTxSave
             )
-        }
+        )
     }
 
     override fun close() {
         logger.info { "Closing Bitcoin notary service" }
-        confidenceListenerExecutorService.shutdownNow()
         blockChainDepositListenerExecutor.shutdownNow()
         peerGroup.stop()
     }

--- a/btc-deposit/src/main/kotlin/com/d3/btc/deposit/listener/BtcConfirmedTxListener.kt
+++ b/btc-deposit/src/main/kotlin/com/d3/btc/deposit/listener/BtcConfirmedTxListener.kt
@@ -1,0 +1,53 @@
+package com.d3.btc.deposit.listener
+
+import mu.KLogging
+import org.bitcoinj.core.Transaction
+import org.bitcoinj.core.TransactionConfidence
+import java.util.*
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Listener of Bitcoin transaction block depth change
+ * @param confidenceLevel - depth of block to wait until calling [txHandler]
+ * @param tx - transaction to listen
+ * @param blockTime - time of block where [tx] appeared for the first time. This time is used in MST
+ * @param txHandler - function that is called when [tx] hits [confidenceLevel] depth in Blockchain
+ */
+class BtcConfirmedTxListener(
+    private val confidenceLevel: Int,
+    private val tx: Transaction,
+    private val blockTime: Date,
+    private val txHandler: (Transaction, Date) -> Unit
+) : TransactionConfidence.Listener {
+    private val processed = AtomicBoolean()
+
+    init {
+        logger.info("Listener for ${tx.hashAsString} has been created. Block time is $blockTime")
+    }
+
+    override fun onConfidenceChanged(
+        confidence: TransactionConfidence,
+        reason: TransactionConfidence.Listener.ChangeReason
+    ) {
+        /*
+        Due to bitoinj library threading issues, we can miss an event of 'depthInBlocks'
+        being exactly 'confidenceLevel'. So we check it to be at least 'confidenceLevel'.
+        This leads D3 to handle the same transaction many times. This is why we use a special
+        flag to check if it has been handled already.
+        */
+        val currentDepth = confidence.depthInBlocks
+        if (currentDepth >= confidenceLevel
+            && processed.compareAndSet(false, true)
+        ) {
+            logger.info { "BTC tx ${tx.hashAsString} was confirmed" }
+            confidence.removeEventListener(this)
+            txHandler(tx, blockTime)
+        }
+        logger.info { "BTC tx ${tx.hashAsString} has $currentDepth confirmations" }
+    }
+
+    /**
+     * Logger
+     */
+    companion object : KLogging()
+}

--- a/btc-deposit/src/main/kotlin/com/d3/btc/deposit/service/BtcWalletListenerRestartService.kt
+++ b/btc-deposit/src/main/kotlin/com/d3/btc/deposit/service/BtcWalletListenerRestartService.kt
@@ -1,0 +1,114 @@
+package com.d3.btc.deposit.service
+
+import com.d3.btc.deposit.config.BtcDepositConfig
+import com.d3.btc.deposit.config.depositConfig
+import com.d3.btc.deposit.handler.BtcDepositTxHandler
+import com.d3.btc.deposit.listener.BtcConfirmedTxListener
+import com.d3.btc.model.BtcAddress
+import com.d3.btc.peer.SharedPeerGroup
+import com.d3.btc.provider.BtcRegisteredAddressesProvider
+import com.d3.commons.sidechain.SideChainEvent
+import com.github.kittinunf.result.Result
+import com.github.kittinunf.result.map
+import io.reactivex.subjects.PublishSubject
+import mu.KLogging
+import org.bitcoinj.core.StoredBlock
+import org.bitcoinj.core.Transaction
+import org.bitcoinj.wallet.Wallet
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+import java.util.concurrent.ExecutorService
+
+/**
+ * Service that is used to restart unconfirmed transactions confidence listeners
+ */
+@Component
+class BtcWalletListenerRestartService(
+    @Autowired private val btcDepositConfig: BtcDepositConfig,
+    @Autowired private val confidenceListenerExecutorService: ExecutorService,
+    @Autowired private val peerGroup: SharedPeerGroup,
+    @Autowired private val btcEventsSource: PublishSubject<SideChainEvent.PrimaryBlockChainEvent>,
+    @Autowired private val btcRegisteredAddressesProvider: BtcRegisteredAddressesProvider
+) {
+
+    /**
+     * Restarts unconfirmed transactions confidence listeners
+     * @param transferWallet - wallet that stores all the D3 Bitcoin transactions. Used to get unconfirmed transactions
+     * @param onTxSave - function that is called to save transaction in wallet
+     */
+    fun restartTransactionListeners(transferWallet: Wallet, onTxSave: () -> Unit): Result<Unit, Exception> {
+        return btcRegisteredAddressesProvider.getRegisteredAddresses().map { registeredAddresses ->
+            transferWallet.walletTransactions
+                .filter { walletTransaction ->
+                    val txDepth = walletTransaction.transaction.confidence.depthInBlocks
+                    txDepth < btcDepositConfig.bitcoin.confidenceLevel
+                }
+                .map { walletTransaction ->
+                    walletTransaction.transaction
+                }
+                .forEach { unconfirmedTx ->
+                    logger.info { "Got unconfirmed transaction ${unconfirmedTx.hashAsString}. Try to restart listener." }
+                    restartUnconfirmedTxListener(unconfirmedTx, registeredAddresses, onTxSave)
+                }
+        }
+    }
+
+    /**
+     * Restarts unconfirmed transaction confidence listener
+     * @param unconfirmedTx - transaction that needs confidence listener restart
+     * @param registeredAddresses - registered addresses
+     * @param onTxSave - function that is called to save transaction in wallet
+     */
+    private fun restartUnconfirmedTxListener(
+        unconfirmedTx: Transaction,
+        registeredAddresses: List<BtcAddress>,
+        onTxSave: () -> Unit
+    ) {
+        // Get tx block hash
+        unconfirmedTx.appearsInHashes?.let { appearsInHashes ->
+            appearsInHashes.keys.firstOrNull()?.let { blockHash ->
+                // Get tx block by hash
+                peerGroup.getBlock(blockHash)?.let { block ->
+                    // Create listener
+                    unconfirmedTx.confidence.addEventListener(
+                        confidenceListenerExecutorService,
+                        createListener(unconfirmedTx, block, registeredAddresses, onTxSave)
+                    )
+                    logger.info("Listener for ${unconfirmedTx.hashAsString} has been restarted")
+                }
+            }
+        }
+    }
+
+    /**
+     * Creates unconfirmed transaction listener
+     * @param unconfirmedTx - unconfirmed transaction which confidence will be listenable
+     * @param block - block of transaction
+     * @param registeredAddresses - registered addresses
+     * @param onTxSave - function that is called to save transaction in wallet
+     * @return restarted listener
+     */
+    private fun createListener(
+        unconfirmedTx: Transaction,
+        block: StoredBlock,
+        registeredAddresses: List<BtcAddress>,
+        onTxSave: () -> Unit
+    )
+            : BtcConfirmedTxListener {
+        return BtcConfirmedTxListener(
+            depositConfig.bitcoin.confidenceLevel,
+            unconfirmedTx,
+            block.header.time,
+            BtcDepositTxHandler(
+                registeredAddresses,
+                btcEventsSource,
+                onTxSave
+            )::handleTx
+        )
+    }
+
+    /**
+     * Logger
+     */
+    companion object : KLogging()
+}

--- a/btc-dw-bridge/src/main/kotlin/com/d3/btc/dwbridge/main.kt
+++ b/btc-dw-bridge/src/main/kotlin/com/d3/btc/dwbridge/main.kt
@@ -32,6 +32,7 @@ const val BTC_DW_BRIDGE_SERVICE_NAME = "btc-dw-bridge"
         "com.d3.btc.listener",
         "com.d3.btc.handler",
         "com.d3.btc.deposit.init",
+        "com.d3.btc.deposit.service",
         "com.d3.btc.peer",
         "com.d3.btc.dwbridge",
         "com.d3.btc.healthcheck"]

--- a/btc/src/main/kotlin/com/d3/btc/peer/SharedPeerGroup.kt
+++ b/btc/src/main/kotlin/com/d3/btc/peer/SharedPeerGroup.kt
@@ -5,6 +5,7 @@ import com.d3.btc.provider.network.BtcNetworkConfigProvider
 import com.google.common.util.concurrent.ListenableFuture
 import mu.KLogging
 import org.bitcoinj.core.PeerGroup
+import org.bitcoinj.core.Sha256Hash
 import org.bitcoinj.wallet.Wallet
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Qualifier
@@ -38,6 +39,8 @@ class SharedPeerGroup(
     private var started = false
     private var stopped = false
 
+    fun getBlock(blockHash: Sha256Hash) = chain?.blockStore?.get(blockHash)
+
     @Synchronized
     override fun startAsync(): ListenableFuture<*>? {
         if (!started) {
@@ -49,10 +52,11 @@ class SharedPeerGroup(
         return null
     }
 
-
     @Synchronized
     override fun stopAsync(): ListenableFuture<*>? {
         if (!stopped) {
+            // Close block store if possible
+            chain?.blockStore?.close()
             val asyncStop = super.stopAsync()
             stopped = true
             return asyncStop

--- a/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/BtcDepositFailResistanceIntegrationTest.kt
+++ b/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/BtcDepositFailResistanceIntegrationTest.kt
@@ -1,0 +1,129 @@
+package integration.btc
+
+import com.d3.commons.sidechain.iroha.CLIENT_DOMAIN
+import com.d3.commons.util.getRandomString
+import com.github.kittinunf.result.failure
+import integration.btc.environment.BtcNotaryTestEnvironment
+import integration.helper.BTC_ASSET
+import integration.helper.BtcIntegrationHelperUtil
+import mu.KLogging
+import org.bitcoinj.core.Address
+import org.bitcoinj.params.RegTestParams
+import org.bitcoinj.wallet.Wallet
+import org.junit.jupiter.api.*
+import java.io.File
+import java.math.BigDecimal
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class BtcDepositFailResistanceIntegrationTest {
+    private val integrationHelper = BtcIntegrationHelperUtil()
+    private val environment = BtcNotaryTestEnvironment(integrationHelper)
+
+    @AfterAll
+    fun dropDown() {
+        environment.close()
+    }
+
+    init {
+        val blockStorageFolder = File(environment.notaryConfig.bitcoin.blockStoragePath)
+        //Clear bitcoin blockchain folder
+        blockStorageFolder.deleteRecursively()
+        //Recreate folder
+        blockStorageFolder.mkdirs()
+        integrationHelper.generateBtcInitialBlocks()
+        integrationHelper.addNotary("test_notary", "test_notary_address")
+    }
+
+    /**
+     * Note: Iroha and bitcoind must be deployed to pass the test.
+     * @given new account and transfer wallet with one unconfirmed transaction related to new account
+     * @when transaction gets all the confirmations after deposit service start
+     * @then balance of new account is increased by 1 btc(or 100.000.000 sat)
+     * and wallet file has one more UTXO
+     */
+    @Test
+    fun testDeposit() {
+        val walletFile = File(environment.notaryConfig.btcTransferWalletPath)
+        val transfersWallet = Wallet.loadFromFile(walletFile)
+        val initUTXOCount = transfersWallet.unspents.size
+        val randomName = String.getRandomString(9)
+        val testClient = "$randomName@$CLIENT_DOMAIN"
+        val btcAddress =
+            integrationHelper.registerBtcAddress(
+                environment.btcAddressGenerationConfig.btcKeysWalletPath,
+                randomName,
+                CLIENT_DOMAIN
+            )
+        val initialBalance = integrationHelper.getIrohaAccountBalance(
+            testClient,
+            BTC_ASSET
+        )
+        val btcAmount = 1
+        //Simulate failure
+        simulateFailRightAfterGettingDeposit(walletFile, btcAddress, btcAmount)
+        //Start deposit service
+        environment.btcNotaryInitialization.init().failure { ex -> fail("Cannot run BTC notary", ex) }
+        //Wait a little to initiale service properly
+        Thread.sleep(DEPOSIT_WAIT_MILLIS)
+        // Confirm coin
+        integrationHelper.generateBtcBlocks(environment.notaryConfig.bitcoin.confidenceLevel - 1)
+        Thread.sleep(DEPOSIT_WAIT_MILLIS)
+        val newBalance = integrationHelper.getIrohaAccountBalance(testClient, BTC_ASSET)
+        Assertions.assertEquals(
+            BigDecimal(initialBalance).add(BigDecimal(btcAmount)).toString(),
+            newBalance
+        )
+        Assertions.assertTrue(environment.btcNotaryInitialization.isWatchedAddress(btcAddress))
+        Assertions.assertEquals(
+            initUTXOCount + 1,
+            Wallet.loadFromFile(walletFile).unspents.size
+        )
+    }
+
+    /**
+     * Simulates failure that happens right after the first deposit transaction confirmation
+     * @param walletFile - file of wallet where all the deposit transactions are stored
+     * @param depositAddress - Bitcoin address to deposit
+     * @param depositBtcAmount - amount of deposit
+     */
+    private fun simulateFailRightAfterGettingDeposit(
+        walletFile: File,
+        depositAddress: String,
+        depositBtcAmount: Int
+    ) {
+        //Load wallet
+        val transfersWallet = Wallet.loadFromFile(walletFile)
+        val networkParams = RegTestParams.get()
+        val txReceivedCountDownLatch = CountDownLatch(1)
+        //Watch address
+        transfersWallet.addWatchedAddress(Address.fromBase58(networkParams, depositAddress))
+        //Listen for transaction
+        transfersWallet.addCoinsReceivedEventListener { _, tx, _, _ ->
+            logger.info { "Got coin ${tx.hashAsString}" }
+            //Save wallet after getting a coin
+            transfersWallet.saveToFile(walletFile)
+            txReceivedCountDownLatch.countDown()
+        }
+        //Creates peer group
+        val peerGroup = environment.createPeerGroup(transfersWallet)
+        peerGroup.startAsync()
+        peerGroup.downloadBlockChain()
+        //Send coins and confirm it with exactly one block
+        integrationHelper.sendBtc(
+            depositAddress,
+            depositBtcAmount,
+            1
+        )
+        //Wait until we get a coin
+        txReceivedCountDownLatch.await(10, TimeUnit.SECONDS)
+        //Stop peer group
+        peerGroup.stop()
+    }
+
+    /**
+     * Logger
+     */
+    companion object : KLogging()
+}

--- a/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/environment/BtcNotaryTestEnvironment.kt
+++ b/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/environment/BtcNotaryTestEnvironment.kt
@@ -2,17 +2,28 @@ package integration.btc.environment
 
 import com.d3.btc.deposit.BTC_DEPOSIT_SERVICE_NAME
 import com.d3.btc.deposit.config.BtcDepositConfig
+import com.d3.btc.deposit.config.depositConfig
 import com.d3.btc.deposit.init.BtcNotaryInitialization
+import com.d3.btc.deposit.service.BtcWalletListenerRestartService
 import com.d3.btc.handler.NewBtcClientRegistrationHandler
 import com.d3.btc.listener.NewBtcClientRegistrationListener
+import com.d3.btc.peer.SharedPeerGroup
 import com.d3.btc.provider.BtcRegisteredAddressesProvider
 import com.d3.btc.provider.network.BtcRegTestConfigProvider
 import com.d3.commons.config.BitcoinConfig
 import com.d3.commons.model.IrohaCredential
+import com.d3.commons.notary.NotaryImpl
+import com.d3.commons.provider.NotaryPeerListProviderImpl
+import com.d3.commons.sidechain.SideChainEvent
 import com.d3.commons.sidechain.iroha.IrohaChainListener
 import com.d3.commons.sidechain.iroha.util.ModelUtil
 import com.d3.commons.util.createPrettySingleThreadPool
 import integration.helper.BtcIntegrationHelperUtil
+import io.reactivex.Observable
+import io.reactivex.subjects.PublishSubject
+import jp.co.soramitsu.iroha.java.IrohaAPI
+import jp.co.soramitsu.iroha.java.QueryAPI
+import org.bitcoinj.wallet.Wallet
 import java.io.Closeable
 import java.io.File
 
@@ -30,8 +41,12 @@ class BtcNotaryTestEnvironment(
     )
 ) : Closeable {
 
+    private val irohaAPI = IrohaAPI(notaryConfig.iroha.hostname, notaryConfig.iroha.port)
+
+    private val queryAPI = QueryAPI(irohaAPI, notaryCredential.accountId, notaryCredential.keyPair)
+
     private val btcRegisteredAddressesProvider = BtcRegisteredAddressesProvider(
-        integrationHelper.queryAPI,
+        queryAPI,
         notaryConfig.registrationAccount,
         notaryConfig.notaryCredential.accountId
     )
@@ -52,30 +67,68 @@ class BtcNotaryTestEnvironment(
             createPrettySingleThreadPool(BTC_DEPOSIT_SERVICE_NAME, "reg-clients-listener")
         )
 
-    private val transferWallet = org.bitcoinj.wallet.Wallet.loadFromFile(File(notaryConfig.btcTransferWalletPath))
+    private val transferWallet by lazy {
+        org.bitcoinj.wallet.Wallet.loadFromFile(File(notaryConfig.btcTransferWalletPath))
+    }
 
-    private val peerGroup = integrationHelper.getPeerGroup(
-        transferWallet,
-        btcNetworkConfigProvider,
-        notaryConfig.bitcoin.blockStoragePath,
-        BitcoinConfig.extractHosts(notaryConfig.bitcoin)
+    private val peerGroup by lazy {
+        createPeerGroup(transferWallet)
+    }
+
+    fun createPeerGroup(transferWallet: Wallet): SharedPeerGroup {
+        return integrationHelper.getPeerGroup(
+            transferWallet,
+            btcNetworkConfigProvider,
+            notaryConfig.bitcoin.blockStoragePath,
+            BitcoinConfig.extractHosts(notaryConfig.bitcoin)
+        )
+    }
+
+    private val confidenceExecutorService =
+        createPrettySingleThreadPool(BTC_DEPOSIT_SERVICE_NAME, "tx-confidence-listener")
+
+    private val peerListProvider = NotaryPeerListProviderImpl(
+        queryAPI,
+        depositConfig.notaryListStorageAccount,
+        depositConfig.notaryListSetterAccount
     )
 
-    val btcNotaryInitialization =
+    private val btcEventsSource = PublishSubject.create<SideChainEvent.PrimaryBlockChainEvent>()
+
+    private val btcEventsObservable: Observable<SideChainEvent.PrimaryBlockChainEvent> = btcEventsSource
+
+    private val notary = NotaryImpl(notaryCredential, irohaAPI, btcEventsObservable, peerListProvider)
+
+    private val btcWalletListenerRestartService by lazy {
+        BtcWalletListenerRestartService(
+            depositConfig,
+            confidenceExecutorService,
+            peerGroup,
+            btcEventsSource,
+            btcRegisteredAddressesProvider
+        )
+    }
+
+    val btcNotaryInitialization by lazy {
         BtcNotaryInitialization(
             peerGroup,
             transferWallet,
             notaryConfig,
-            notaryCredential,
-            integrationHelper.irohaAPI,
+            notary,
             btcRegisteredAddressesProvider,
+            btcEventsSource,
             irohaChainListener,
             newBtcClientRegistrationListener,
+            btcWalletListenerRestartService,
+            confidenceExecutorService,
             btcNetworkConfigProvider
         )
+    }
 
     override fun close() {
         integrationHelper.close()
+        irohaAPI.close()
+        confidenceExecutorService.shutdownNow()
         irohaChainListener.close()
         //Clear bitcoin blockchain folder
         File(notaryConfig.bitcoin.blockStoragePath).deleteRecursively()

--- a/notary-btc-integration-test/src/main/kotlin/integration/helper/BtcIntegrationHelperUtil.kt
+++ b/notary-btc-integration-test/src/main/kotlin/integration/helper/BtcIntegrationHelperUtil.kt
@@ -25,7 +25,6 @@ import com.github.kittinunf.result.map
 import mu.KLogging
 import org.bitcoinj.core.Address
 import org.bitcoinj.core.ECKey
-import org.bitcoinj.core.PeerGroup
 import org.bitcoinj.crypto.DeterministicKey
 import org.bitcoinj.params.RegTestParams
 import org.bitcoinj.script.ScriptBuilder
@@ -145,7 +144,7 @@ class BtcIntegrationHelperUtil(peers: Int = 1) : IrohaIntegrationHelperUtil(peer
         btcNetworkConfigProvider: BtcNetworkConfigProvider,
         blockStoragePath: String,
         hosts: List<String>
-    ): PeerGroup {
+    ): SharedPeerGroup {
         return SharedPeerGroup(btcNetworkConfigProvider, wallet, blockStoragePath, hosts)
     }
 

--- a/notary-registration/src/main/kotlin/com/d3/commons/registration/main.kt
+++ b/notary-registration/src/main/kotlin/com/d3/commons/registration/main.kt
@@ -32,4 +32,3 @@ fun main(args: Array<String>) {
         System.exit(1)
     }
 }
-


### PR DESCRIPTION
### Description of the Change
This is how deposit service works:
1) Listen to Bitcoin blockchain
2) Add depth listener to transactions that we are interested in (deposits to our clients)
3) Wait for 6 blocks
4)  Publish deposit event

If deposit service fails before transaction hits 6 blocks, we will lose money in Iroha after service restart because there will be no listeners for unconfirmed transactions. We have to manually check if we have unconfirmed transactions and reset depth listeners once again.