### PR TITLE
Fixed BTC withdrawal

### DIFF
--- a/btc-address-generation/src/main/kotlin/com/d3/btc/generation/init/BtcAddressGenerationInitialization.kt
+++ b/btc-address-generation/src/main/kotlin/com/d3/btc/generation/init/BtcAddressGenerationInitialization.kt
@@ -146,7 +146,7 @@ class BtcAddressGenerationInitialization(
             val notaryKeys = details.values
             if (!notaryKeys.isEmpty()) {
                 btcPublicKeyProvider.checkAndCreateMultiSigAddress(
-                    notaryKeys,
+                    notaryKeys.toList(),
                     addressType,
                     time,
                     nodeId

--- a/btc/src/main/kotlin/com/d3/btc/helper/address/BtcAddressHelper.kt
+++ b/btc/src/main/kotlin/com/d3/btc/helper/address/BtcAddressHelper.kt
@@ -1,9 +1,9 @@
 package com.d3.btc.helper.address
 
-import org.bitcoinj.core.AddressFormatException
-import org.bitcoinj.core.Base58
-import org.bitcoinj.core.ScriptException
-import org.bitcoinj.core.TransactionOutput
+import org.bitcoinj.core.*
+import org.bitcoinj.script.Script
+import org.bitcoinj.script.ScriptBuilder
+import org.bitcoinj.script.ScriptBuilder.createP2SHOutputScript
 
 /**
  * Safely takes base58 encoded address from tx output
@@ -18,6 +18,33 @@ fun outPutToBase58Address(output: TransactionOutput): String {
         return "[undefined]"
     }
 }
+
+/**
+ * Creates redeem script for MS address using given [pubKeys]
+ * @param pubKeys - public keys that are used in MS address creation
+ * @return redeem script
+ */
+fun createMsRedeemScript(pubKeys: List<String>): Script {
+    val ecPubKeys = pubKeys.map { pubKey -> toEcPubKey(pubKey) }
+    return ScriptBuilder.createRedeemScript(getSignThreshold(pubKeys), ecPubKeys)
+}
+
+/**
+ * Creates MS address using given [notaryKeys]
+ * @param notaryKeys - public keys that are used to create MS address
+ * @param networkParameters - network parameters(RegTest, TestNet or MainNet)
+ * @return MS script
+ */
+fun createMsAddress(notaryKeys: List<String>, networkParameters: NetworkParameters): Address {
+    return createP2SHOutputScript(createMsRedeemScript(notaryKeys)).getToAddress(networkParameters)
+}
+
+/**
+ * Creates EC pub key from hex
+ * @param pubKey - public key in hex encoding
+ * @return EC pub key
+ */
+fun toEcPubKey(pubKey: String) = ECKey.fromPublicOnly(Utils.parseAsHexOrBase58(pubKey))
 
 /**
  * Calculate threshold for signing

--- a/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/BtcMultiWithdrawalIntegrationTest.kt
+++ b/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/BtcMultiWithdrawalIntegrationTest.kt
@@ -1,68 +1,92 @@
 package integration.btc
 
+import com.d3.btc.helper.address.outPutToBase58Address
 import com.d3.btc.helper.currency.satToBtc
+import com.d3.btc.model.BtcAddressType
+import com.d3.btc.provider.generation.ADDRESS_GENERATION_NODE_ID_KEY
+import com.d3.btc.provider.generation.ADDRESS_GENERATION_TIME_KEY
 import com.d3.btc.withdrawal.handler.CurrentFeeRate
 import com.d3.commons.sidechain.iroha.CLIENT_DOMAIN
 import com.d3.commons.sidechain.iroha.util.ModelUtil
 import com.d3.commons.util.getRandomString
 import com.github.kittinunf.result.failure
+import integration.btc.environment.BtcAddressGenerationTestEnvironment
 import integration.btc.environment.BtcWithdrawalTestEnvironment
 import integration.helper.BTC_ASSET
 import integration.helper.BtcIntegrationHelperUtil
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
-import org.bitcoinj.core.Address
+import org.bitcoinj.params.RegTestParams
 import org.junit.jupiter.api.*
 import java.io.File
+import java.math.BigDecimal
+import java.util.*
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 
-private const val TOTAL_TESTS = 1
-
-@Disabled
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class BtcMultiWithdrawalIntegrationTest {
 
     private val peers = 3
     private val integrationHelper = BtcIntegrationHelperUtil(peers)
-    private val environments = ArrayList<BtcWithdrawalTestEnvironment>()
-    private lateinit var changeAddress: Address
+    private val withdrawalEnvironments = ArrayList<BtcWithdrawalTestEnvironment>()
+    private val addressGenerationEnvironments = ArrayList<BtcAddressGenerationTestEnvironment>()
 
     @AfterAll
     fun dropDown() {
-        environments.forEach { environment ->
+        withdrawalEnvironments.forEach { environment ->
+            environment.close()
+        }
+        addressGenerationEnvironments.forEach { environment ->
             environment.close()
         }
     }
 
     @BeforeAll
     fun setUp() {
+        integrationHelper.generateBtcInitialBlocks()
         CurrentFeeRate.set(DEFAULT_FEE_RATE)
+        val testNames = ArrayList<String>()
+        repeat(peers) { peer ->
+            testNames.add("multi_withdrawal_${String.getRandomString(5)}_$peer")
+            integrationHelper.addNotary("test_notary_$peer", "test")
+        }
         var peerCount = 0
         integrationHelper.accountHelper.btcWithdrawalAccounts
             .forEach { withdrawalAccount ->
-                integrationHelper.addNotary("test_notary_$peerCount", "test")
-                val testName = "multi_withdrawal_${String.getRandomString(5)}_${peerCount++}"
+                val testName = testNames[peerCount++]
                 val withdrawalConfig = integrationHelper.configHelper.createBtcWithdrawalConfig(testName)
                 val environment =
                     BtcWithdrawalTestEnvironment(integrationHelper, testName, withdrawalConfig, withdrawalAccount)
-                environments.add(environment)
+                environment.withdrawalTransferEventHandler.addNewBtcTransactionListener { tx ->
+                    environment.createdTransactions[tx.hashAsString] = Pair(System.currentTimeMillis(), tx)
+                }
+                withdrawalEnvironments.add(environment)
                 val blockStorageFolder = File(environment.btcWithdrawalConfig.bitcoin.blockStoragePath)
                 //Clear bitcoin blockchain folder
                 blockStorageFolder.deleteRecursively()
                 //Recreate folder
                 blockStorageFolder.mkdirs()
             }
-        val someEnvironment = environments.first()
-        integrationHelper.generateBtcInitialBlocks()
-        //TODO don't forget to add chain address to transfers wallet
-        integrationHelper.genChangeBtcAddress(someEnvironment.btcWithdrawalConfig.btcKeysWalletPath)
-            .fold({ address -> changeAddress = address }, { ex -> throw  ex })
-        integrationHelper.preGenFreeBtcAddresses(
-            someEnvironment.btcWithdrawalConfig.btcKeysWalletPath,
-            TOTAL_TESTS * 2
-        )
-        environments.forEach { environment ->
-            environment.transactionHelper.addToBlackList(changeAddress.toBase58())
+
+        peerCount = 0
+        integrationHelper.accountHelper.mstRegistrationAccounts.forEach { mstRegistrationAccount ->
+            val testName = testNames[peerCount++]
+            val environment = BtcAddressGenerationTestEnvironment(
+                integrationHelper,
+                btcGenerationConfig = integrationHelper.configHelper.createBtcAddressGenerationConfig(0, testName),
+                mstRegistrationCredential = mstRegistrationAccount
+            )
+            addressGenerationEnvironments.add(environment)
+            GlobalScope.launch {
+                environment.btcAddressGenerationInitialization.init().failure { ex -> throw ex }
+            }
+        }
+        //Wait services to init
+        Thread.sleep(WAIT_PREGEN_PROCESS_MILLIS)
+        generateAddress(BtcAddressType.CHANGE)
+
+        withdrawalEnvironments.forEach { environment ->
             GlobalScope.launch {
                 environment.btcWithdrawalInitialization.init().failure { ex -> throw ex }
             }
@@ -72,18 +96,21 @@ class BtcMultiWithdrawalIntegrationTest {
     /**
      * Note: Iroha and bitcoind must be deployed to pass the test.
      * @given 3 withdrawal services and  two registered BTC clients. 1st client has no BTC
-     * @when 1st client sends SAT 10000 to 2nd client
-     * @then no transaction is created, because 1st client has no money at all.
+     * @when 1st client sends SAT 1 to 2nd client
+     * @then no transaction is created, because SAT 1 is considered dust.
      * Money sent to 2nd client is rolled back to 1st client
      */
+    @Disabled
     @Test
     fun testWithdrawalMultisigRollback() {
-        val environment = environments.first()
+        val environment = withdrawalEnvironments.first()
         val initTxCount = environment.createdTransactions.size
-        val amount = satToBtc(10000L)
+        val amount = satToBtc(1L)
         val randomNameSrc = String.getRandomString(9)
         val testClientSrcKeypair = ModelUtil.generateKeypair()
         val testClientSrc = "$randomNameSrc@$CLIENT_DOMAIN"
+        generateAddress(BtcAddressType.FREE)
+        generateAddress(BtcAddressType.FREE)
         integrationHelper.registerBtcAddressNoPreGen(randomNameSrc, CLIENT_DOMAIN, testClientSrcKeypair)
         val randomNameDest = String.getRandomString(9)
         val btcAddressDest = integrationHelper.registerBtcAddressNoPreGen(randomNameDest, CLIENT_DOMAIN)
@@ -102,5 +129,89 @@ class BtcMultiWithdrawalIntegrationTest {
         assertEquals(initTxCount, environment.createdTransactions.size)
         assertEquals(initialSrcBalance, integrationHelper.getIrohaAccountBalance(testClientSrc, BTC_ASSET))
         environment.transactionHelper.addToBlackList(btcAddressDest)
+    }
+
+    /**
+     * Note: Iroha and bitcoind must be deployed to pass the test.
+     * @given two registered BTC clients. 1st client has 1 BTC in wallet.
+     * @when 1st client sends SAT 10000 to 2nd client
+     * @then new well constructed BTC transaction and one signature appear.
+     * Transaction is properly signed, sent to Bitcoin network and not considered unsigned anymore
+     */
+    @Test
+    fun testWithdrawal() {
+        val environment = withdrawalEnvironments.first()
+        val initTxCount = environment.createdTransactions.size
+        val amount = satToBtc(10000L)
+        val randomNameSrc = String.getRandomString(9)
+        val testClientSrcKeypair = ModelUtil.generateKeypair()
+        val testClientSrc = "$randomNameSrc@$CLIENT_DOMAIN"
+        generateAddress(BtcAddressType.FREE)
+        generateAddress(BtcAddressType.FREE)
+        val btcAddressSrc =
+            integrationHelper.registerBtcAddressNoPreGen(randomNameSrc, CLIENT_DOMAIN, testClientSrcKeypair)
+        integrationHelper.sendBtc(btcAddressSrc, 1, environment.btcWithdrawalConfig.bitcoin.confidenceLevel)
+        val randomNameDest = String.getRandomString(9)
+        val btcAddressDest = integrationHelper.registerBtcAddressNoPreGen(randomNameDest, CLIENT_DOMAIN)
+        integrationHelper.addIrohaAssetTo(testClientSrc, BTC_ASSET, amount)
+        integrationHelper.transferAssetIrohaFromClient(
+            testClientSrc,
+            testClientSrcKeypair,
+            testClientSrc,
+            environment.btcWithdrawalConfig.withdrawalCredential.accountId,
+            BTC_ASSET,
+            btcAddressDest,
+            amount.toPlainString()
+        )
+        Thread.sleep(WITHDRAWAL_WAIT_MILLIS)
+        assertEquals(initTxCount + 1, environment.createdTransactions.size)
+        val createdWithdrawalTx = environment.getLastCreatedTxHash()
+        environment.signCollector.getSignatures(createdWithdrawalTx).fold({ signatures ->
+            BtcWithdrawalIntegrationTest.logger.info { "signatures $signatures" }
+            assertEquals(peers, signatures[0]!!.size)
+        }, { ex -> fail(ex) })
+        environment.transactionHelper.addToBlackList(btcAddressSrc)
+        environment.transactionHelper.addToBlackList(btcAddressDest)
+        assertEquals(
+            0,
+            BigDecimal.ZERO.compareTo(
+                BigDecimal(integrationHelper.getIrohaAccountBalance(testClientSrc, BTC_ASSET))
+            )
+        )
+        assertFalse(environment.unsignedTransactions.isUnsigned(createdWithdrawalTx))
+        assertEquals(2, environment.getLastCreatedTx().outputs.size)
+        Assertions.assertNotNull(environment.getLastCreatedTx().outputs.firstOrNull { transactionOutput ->
+            outPutToBase58Address(
+                transactionOutput
+            ) == btcAddressDest
+        })
+    }
+
+    /**
+     * Generates address
+     * @param addressType - type of address to generate
+     * @return address
+     */
+    private fun generateAddress(addressType: BtcAddressType): String {
+        val environment = addressGenerationEnvironments.first()
+        val sessionAccountName = addressType.createSessionAccountName()
+        environment.btcKeyGenSessionProvider.createPubKeyCreationSession(
+            sessionAccountName,
+            environment.btcGenerationConfig.nodeId
+        ).fold({ BtcAddressGenerationIntegrationTest.logger.info { "session $sessionAccountName was created" } },
+            { ex -> fail("cannot create session", ex) })
+        environment.triggerProvider.trigger(sessionAccountName)
+        Thread.sleep(WAIT_PREGEN_PROCESS_MILLIS)
+        val sessionDetails =
+            integrationHelper.getAccountDetails(
+                "$sessionAccountName@btcSession",
+                environment.btcGenerationConfig.registrationAccount.accountId
+            )
+        val notaryKeys =
+            sessionDetails.entries.filter { entry ->
+                entry.key != ADDRESS_GENERATION_TIME_KEY
+                        && entry.key != ADDRESS_GENERATION_NODE_ID_KEY
+            }.map { entry -> entry.value }
+        return com.d3.btc.helper.address.createMsAddress(notaryKeys, RegTestParams.get()).toBase58()
     }
 }

--- a/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/environment/BtcWithdrawalTestEnvironment.kt
+++ b/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/environment/BtcWithdrawalTestEnvironment.kt
@@ -35,7 +35,6 @@ import org.bitcoinj.wallet.Wallet
 import java.io.Closeable
 import java.io.File
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.Executors
 
 /**
  * Bitcoin withdrawal service testing environment

--- a/notary-btc-integration-test/src/main/kotlin/integration/helper/BtcIntegrationHelperUtil.kt
+++ b/notary-btc-integration-test/src/main/kotlin/integration/helper/BtcIntegrationHelperUtil.kt
@@ -1,5 +1,6 @@
 package integration.helper
 
+import com.d3.btc.helper.address.createMsAddress
 import com.d3.btc.helper.currency.satToBtc
 import com.d3.btc.model.AddressInfo
 import com.d3.btc.peer.SharedPeerGroup
@@ -24,10 +25,8 @@ import com.github.kittinunf.result.flatMap
 import com.github.kittinunf.result.map
 import mu.KLogging
 import org.bitcoinj.core.Address
-import org.bitcoinj.core.ECKey
 import org.bitcoinj.crypto.DeterministicKey
 import org.bitcoinj.params.RegTestParams
-import org.bitcoinj.script.ScriptBuilder
 import org.bitcoinj.wallet.Wallet
 import java.io.File
 import java.math.BigDecimal
@@ -148,11 +147,6 @@ class BtcIntegrationHelperUtil(peers: Int = 1) : IrohaIntegrationHelperUtil(peer
         return SharedPeerGroup(btcNetworkConfigProvider, wallet, blockStoragePath, hosts)
     }
 
-    private fun createMsAddress(keys: List<ECKey>): Address {
-        val script = ScriptBuilder.createP2SHOutputScript(1, keys)
-        return script.getToAddress(RegTestParams.get())
-    }
-
     /**
      * Generates one BTC address that can be registered later
      * @param walletFilePath - path to wallet file
@@ -189,7 +183,7 @@ class BtcIntegrationHelperUtil(peers: Int = 1) : IrohaIntegrationHelperUtil(peer
         val walletFile = File(walletFilePath)
         val wallet = Wallet.loadFromFile(walletFile)
         val key = wallet.freshReceiveKey()
-        val address = createMsAddress(listOf(key))
+        val address = createMsAddress(listOf(key.publicKeyAsHex), RegTestParams.get())
         wallet.addWatchedAddress(address)
         wallet.saveToFile(walletFile)
         logger.info { "generated address $address" }


### PR DESCRIPTION
### Description of the Change
Bitcoin multisig transaction signatures must be ordered the same way their corresponding public keys were ordered in redeem script. Unfortunately, it was not the case. Now ordering is fixed.
We didn't face this problem before, because all the test were written in 1 node environment, so we couldn't face any ordering issues.
This behavior is guarded by intgeration tests.