### PR TITLE
Fixed Network parameters

### DIFF
--- a/btc-deposit/src/main/kotlin/com/d3/btc/deposit/handler/BtcDepositTxHandler.kt
+++ b/btc-deposit/src/main/kotlin/com/d3/btc/deposit/handler/BtcDepositTxHandler.kt
@@ -3,6 +3,7 @@ package com.d3.btc.deposit.handler
 import com.d3.btc.helper.address.outPutToBase58Address
 import com.d3.btc.helper.currency.satToBtc
 import com.d3.btc.model.BtcAddress
+import com.d3.btc.provider.network.BtcNetworkConfigProvider
 import com.d3.commons.sidechain.SideChainEvent
 import io.reactivex.subjects.PublishSubject
 import mu.KLogging
@@ -23,6 +24,7 @@ private const val TWO_HOURS_MILLIS = 2 * 60 * 60 * 1000L
 class BtcDepositTxHandler(
     private val registeredAddresses: List<BtcAddress>,
     private val btcEventsSource: PublishSubject<SideChainEvent.PrimaryBlockChainEvent>,
+    private val btcNetworkConfigProvider: BtcNetworkConfigProvider,
     private val onTxSave: () -> Unit
 ) {
 
@@ -33,7 +35,7 @@ class BtcDepositTxHandler(
      */
     fun handleTx(tx: Transaction, blockTime: Date) {
         tx.outputs.forEach { output ->
-            val txBtcAddress = outPutToBase58Address(output)
+            val txBtcAddress = outPutToBase58Address(output, btcNetworkConfigProvider.getConfig())
             logger.info { "Tx ${tx.hashAsString} has output address $txBtcAddress" }
             val btcAddress = registeredAddresses.firstOrNull { btcAddress -> btcAddress.address == txBtcAddress }
             if (btcAddress != null) {

--- a/btc-deposit/src/main/kotlin/com/d3/btc/deposit/init/BtcNotaryInitialization.kt
+++ b/btc-deposit/src/main/kotlin/com/d3/btc/deposit/init/BtcNotaryInitialization.kt
@@ -119,6 +119,7 @@ class BtcNotaryInitialization(
                 btcRegisteredAddressesProvider,
                 btcEventsSource,
                 confidenceListenerExecutorService,
+                btcNetworkConfigProvider,
                 confidenceLevel,
                 ::onTxSave
             )

--- a/btc-deposit/src/main/kotlin/com/d3/btc/deposit/listener/BitcoinBlockChainDepositListener.kt
+++ b/btc-deposit/src/main/kotlin/com/d3/btc/deposit/listener/BitcoinBlockChainDepositListener.kt
@@ -2,6 +2,7 @@ package com.d3.btc.deposit.listener
 
 import com.d3.btc.deposit.handler.BtcDepositTxHandler
 import com.d3.btc.provider.BtcRegisteredAddressesProvider
+import com.d3.btc.provider.network.BtcNetworkConfigProvider
 import com.d3.commons.sidechain.SideChainEvent
 import io.reactivex.subjects.PublishSubject
 import mu.KLogging
@@ -18,12 +19,14 @@ private const val DAY_MILLIS = 24 * 60 * 60 * 1000L
  * @param btcRegisteredAddressesProvider - Bitcoin registered addresses provider
  * @param btcEventsSource - observable that is used to publish Bitcoin deposit events
  * @param confidenceListenerExecutorService - executor service that is used to execute 'confidence change' events
+ * @param btcNetworkConfigProvider - Bitcoin Network configuration provider
  * @param onTxSave - function that is called to save transaction
  */
 class BitcoinBlockChainDepositListener(
     private val btcRegisteredAddressesProvider: BtcRegisteredAddressesProvider,
     private val btcEventsSource: PublishSubject<SideChainEvent.PrimaryBlockChainEvent>,
     private val confidenceListenerExecutorService: ExecutorService,
+    private val btcNetworkConfigProvider: BtcNetworkConfigProvider,
     private val confidenceLevel: Int,
     private val onTxSave: () -> Unit
 ) : BlocksDownloadedEventListener {
@@ -51,7 +54,8 @@ class BitcoinBlockChainDepositListener(
                         registeredAddresses,
                         confidenceLevel,
                         confidenceListenerExecutorService,
-                        BtcDepositTxHandler(registeredAddresses, btcEventsSource, onTxSave),
+                        BtcDepositTxHandler(registeredAddresses, btcEventsSource, btcNetworkConfigProvider, onTxSave),
+                        btcNetworkConfigProvider,
                         onTxSave
                     )
                 block.transactions?.forEach { tx ->

--- a/btc-deposit/src/main/kotlin/com/d3/btc/deposit/listener/BitcoinTransactionListener.kt
+++ b/btc-deposit/src/main/kotlin/com/d3/btc/deposit/listener/BitcoinTransactionListener.kt
@@ -3,6 +3,7 @@ package com.d3.btc.deposit.listener
 import com.d3.btc.deposit.handler.BtcDepositTxHandler
 import com.d3.btc.helper.address.outPutToBase58Address
 import com.d3.btc.model.BtcAddress
+import com.d3.btc.provider.network.BtcNetworkConfigProvider
 import mu.KLogging
 import org.bitcoinj.core.Transaction
 import java.util.*
@@ -21,6 +22,7 @@ class BitcoinTransactionListener(
     private val confidenceLevel: Int,
     private val confidenceListenerExecutor: ExecutorService,
     private val btcDepositTxHandler: BtcDepositTxHandler,
+    private val btcNetworkConfigProvider: BtcNetworkConfigProvider,
     private val onTxSave: () -> Unit
 ) {
     fun onTransaction(tx: Transaction, blockTime: Date) {
@@ -55,7 +57,7 @@ class BitcoinTransactionListener(
     private fun hasRegisteredAddresses(tx: Transaction): Boolean {
         return registeredAddresses.any { registeredBtcAddress ->
             tx.outputs.map { out ->
-                outPutToBase58Address(out)
+                outPutToBase58Address(out, btcNetworkConfigProvider.getConfig())
             }.contains(registeredBtcAddress.address)
         }
     }

--- a/btc-deposit/src/main/kotlin/com/d3/btc/deposit/service/BtcWalletListenerRestartService.kt
+++ b/btc-deposit/src/main/kotlin/com/d3/btc/deposit/service/BtcWalletListenerRestartService.kt
@@ -7,6 +7,7 @@ import com.d3.btc.deposit.listener.BtcConfirmedTxListener
 import com.d3.btc.model.BtcAddress
 import com.d3.btc.peer.SharedPeerGroup
 import com.d3.btc.provider.BtcRegisteredAddressesProvider
+import com.d3.btc.provider.network.BtcNetworkConfigProvider
 import com.d3.commons.sidechain.SideChainEvent
 import com.github.kittinunf.result.Result
 import com.github.kittinunf.result.map
@@ -28,7 +29,8 @@ class BtcWalletListenerRestartService(
     @Autowired private val confidenceListenerExecutorService: ExecutorService,
     @Autowired private val peerGroup: SharedPeerGroup,
     @Autowired private val btcEventsSource: PublishSubject<SideChainEvent.PrimaryBlockChainEvent>,
-    @Autowired private val btcRegisteredAddressesProvider: BtcRegisteredAddressesProvider
+    @Autowired private val btcRegisteredAddressesProvider: BtcRegisteredAddressesProvider,
+    @Autowired private val btcNetworkConfigProvider: BtcNetworkConfigProvider
 ) {
 
     /**
@@ -102,6 +104,7 @@ class BtcWalletListenerRestartService(
             BtcDepositTxHandler(
                 registeredAddresses,
                 btcEventsSource,
+                btcNetworkConfigProvider,
                 onTxSave
             )::handleTx
         )

--- a/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/transaction/TransactionHelper.kt
+++ b/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/transaction/TransactionHelper.kt
@@ -170,7 +170,7 @@ class TransactionHelper(
 
         logger.info("Got unspents\n${unspents.map { unspent ->
             Pair(
-                outPutToBase58Address(unspent),
+                outPutToBase58Address(unspent, btcNetworkConfigProvider.getConfig()),
                 unspent.value
             )
         }}")
@@ -233,7 +233,7 @@ class TransactionHelper(
 
     // Checks if fee output was addressed to available address
     protected fun isAvailableOutput(availableAddresses: Set<String>, output: TransactionOutput): Boolean {
-        val btcAddress = outPutToBase58Address(output)
+        val btcAddress = outPutToBase58Address(output, btcNetworkConfigProvider.getConfig())
         return availableAddresses.contains(btcAddress)
     }
 

--- a/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/transaction/TransactionSigner.kt
+++ b/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/transaction/TransactionSigner.kt
@@ -5,6 +5,7 @@ import com.d3.btc.helper.address.getSignThreshold
 import com.d3.btc.helper.address.outPutToBase58Address
 import com.d3.btc.helper.address.toEcPubKey
 import com.d3.btc.provider.BtcRegisteredAddressesProvider
+import com.d3.btc.provider.network.BtcNetworkConfigProvider
 import com.d3.btc.wallet.safeLoad
 import com.d3.btc.withdrawal.provider.BtcChangeAddressProvider
 import com.github.kittinunf.result.Result
@@ -27,7 +28,8 @@ import com.d3.commons.util.hex
 @Component
 class TransactionSigner(
     @Autowired private val btcRegisteredAddressesProvider: BtcRegisteredAddressesProvider,
-    @Autowired private val btcChangeAddressesProvider: BtcChangeAddressProvider
+    @Autowired private val btcChangeAddressesProvider: BtcChangeAddressProvider,
+    @Autowired private val btcNetworkConfigProvider: BtcNetworkConfigProvider
 ) {
     /**
      * Signs transaction using available private keys from wallet
@@ -62,7 +64,7 @@ class TransactionSigner(
         var inputIndex = 0
         val signatures = ArrayList<InputSignature>()
         tx.inputs.forEach { input ->
-            getUsedPubKeys(outPutToBase58Address(input.connectedOutput!!)).fold({ pubKeys ->
+            getUsedPubKeys(outPutToBase58Address(input.connectedOutput!!,btcNetworkConfigProvider.getConfig())).fold({ pubKeys ->
                 val keyPair = getPrivPubKeyPair(pubKeys, wallet)
                 if (keyPair != null) {
                     val redeem = createMsRedeemScript(pubKeys)

--- a/btc/src/main/kotlin/com/d3/btc/helper/address/BtcAddressHelper.kt
+++ b/btc/src/main/kotlin/com/d3/btc/helper/address/BtcAddressHelper.kt
@@ -11,11 +11,12 @@ private const val UNDEFINED_ADDRESS = "[undefined]"
  * Safely takes base58 encoded address from tx output
  *
  * @param output - tx output to take address from
+ * @param networkParameters - network parameters(RegTest, TestNet or MainNet)
  * @return - base58 encoded address or "[undefined]" if exception occurred
  */
-fun outPutToBase58Address(output: TransactionOutput): String {
+fun outPutToBase58Address(output: TransactionOutput, networkParameters: NetworkParameters): String {
     try {
-        val address = output.scriptPubKey?.getToAddress(output.params)?.toBase58()
+        val address = output.scriptPubKey?.getToAddress(networkParameters)?.toBase58()
         return if (address != null) {
             address
         } else {

--- a/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/BtcMultiWithdrawalIntegrationTest.kt
+++ b/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/BtcMultiWithdrawalIntegrationTest.kt
@@ -183,6 +183,7 @@ class BtcMultiWithdrawalIntegrationTest {
         Assertions.assertNotNull(environment.getLastCreatedTx().outputs.firstOrNull { transactionOutput ->
             outPutToBase58Address(
                 transactionOutput
+                , RegTestParams.get()
             ) == btcAddressDest
         })
     }

--- a/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/BtcWithdrawalFailResistanceIntegrationTest.kt
+++ b/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/BtcWithdrawalFailResistanceIntegrationTest.kt
@@ -11,6 +11,7 @@ import integration.btc.environment.BtcWithdrawalTestEnvironment
 import integration.helper.BTC_ASSET
 import integration.helper.BtcIntegrationHelperUtil
 import org.bitcoinj.core.Address
+import org.bitcoinj.params.RegTestParams
 import org.junit.Assert.assertNotNull
 import org.junit.jupiter.api.*
 import java.io.File
@@ -112,11 +113,13 @@ class BtcWithdrawalFailResistanceIntegrationTest {
         assertNotNull(environment.getLastCreatedTx().outputs.firstOrNull { transactionOutput ->
             outPutToBase58Address(
                 transactionOutput
+                , RegTestParams.get()
             ) == btcAddressDest
         })
         assertNotNull(environment.getLastCreatedTx().outputs.firstOrNull { transactionOutput ->
             outPutToBase58Address(
                 transactionOutput
+                , RegTestParams.get()
             ) == changeAddress.toBase58()
         })
     }

--- a/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/BtcWithdrawalIntegrationTest.kt
+++ b/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/BtcWithdrawalIntegrationTest.kt
@@ -13,6 +13,7 @@ import integration.helper.BtcIntegrationHelperUtil
 import jp.co.soramitsu.crypto.ed25519.Ed25519Sha3
 import mu.KLogging
 import org.bitcoinj.core.Address
+import org.bitcoinj.params.RegTestParams
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.assertNotNull
 import java.io.File
@@ -121,11 +122,13 @@ class BtcWithdrawalIntegrationTest {
         assertNotNull(environment.getLastCreatedTx().outputs.firstOrNull { transactionOutput ->
             outPutToBase58Address(
                 transactionOutput
+                , RegTestParams.get()
             ) == btcAddressDest
         })
         assertNotNull(environment.getLastCreatedTx().outputs.firstOrNull { transactionOutput ->
             outPutToBase58Address(
                 transactionOutput
+                , RegTestParams.get()
             ) == changeAddress.toBase58()
         })
     }
@@ -289,11 +292,13 @@ class BtcWithdrawalIntegrationTest {
         assertNotNull(environment.getLastCreatedTx().outputs.firstOrNull { transactionOutput ->
             outPutToBase58Address(
                 transactionOutput
+                , RegTestParams.get()
             ) == btcAddressDest
         })
         assertNotNull(environment.getLastCreatedTx().outputs.firstOrNull { transactionOutput ->
             outPutToBase58Address(
                 transactionOutput
+                , RegTestParams.get()
             ) == changeAddress.toBase58()
         })
     }
@@ -413,11 +418,13 @@ class BtcWithdrawalIntegrationTest {
         assertNotNull(environment.getLastCreatedTx().outputs.firstOrNull { transactionOutput ->
             outPutToBase58Address(
                 transactionOutput
+                , RegTestParams.get()
             ) == btcAddressDest
         })
         assertNotNull(environment.getLastCreatedTx().outputs.firstOrNull { transactionOutput ->
             outPutToBase58Address(
                 transactionOutput
+                , RegTestParams.get()
             ) == changeAddress.toBase58()
         })
         environment.transactionHelper.addToBlackList(btcAddressSrc)
@@ -504,11 +511,13 @@ class BtcWithdrawalIntegrationTest {
         assertNotNull(environment.getLastCreatedTx().outputs.firstOrNull { transactionOutput ->
             outPutToBase58Address(
                 transactionOutput
+                , RegTestParams.get()
             ) == btcAddressDest
         })
         assertNotNull(environment.getLastCreatedTx().outputs.firstOrNull { transactionOutput ->
             outPutToBase58Address(
                 transactionOutput
+                , RegTestParams.get()
             ) == changeAddress.toBase58()
         })
         assertEquals(
@@ -565,11 +574,13 @@ class BtcWithdrawalIntegrationTest {
         assertNotNull(environment.getLastCreatedTx().outputs.firstOrNull { transactionOutput ->
             outPutToBase58Address(
                 transactionOutput
+                , RegTestParams.get()
             ) == btcAddressDest
         })
         assertNotNull(environment.getLastCreatedTx().outputs.firstOrNull { transactionOutput ->
             outPutToBase58Address(
                 transactionOutput
+                , RegTestParams.get()
             ) == changeAddress.toBase58()
         })
         assertFalse(environment.unsignedTransactions.isUnsigned(createdWithdrawalTx))

--- a/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/environment/BtcNotaryTestEnvironment.kt
+++ b/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/environment/BtcNotaryTestEnvironment.kt
@@ -105,7 +105,8 @@ class BtcNotaryTestEnvironment(
             confidenceExecutorService,
             peerGroup,
             btcEventsSource,
-            btcRegisteredAddressesProvider
+            btcRegisteredAddressesProvider,
+            btcNetworkConfigProvider
         )
     }
 

--- a/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/environment/BtcWithdrawalTestEnvironment.kt
+++ b/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/environment/BtcWithdrawalTestEnvironment.kt
@@ -31,6 +31,7 @@ import io.grpc.ManagedChannelBuilder
 import jp.co.soramitsu.iroha.java.IrohaAPI
 import org.bitcoinj.core.Transaction
 import org.bitcoinj.core.TransactionOutput
+import org.bitcoinj.params.RegTestParams
 import org.bitcoinj.wallet.Wallet
 import java.io.Closeable
 import java.io.File
@@ -143,13 +144,17 @@ class BtcWithdrawalTestEnvironment(
         )
     private val transactionCreator =
         TransactionCreator(btcChangeAddressProvider, btcNetworkConfigProvider, transactionHelper)
-    private val transactionSigner = TransactionSigner(btcRegisteredAddressesProvider, btcChangeAddressProvider)
+    private val transactionSigner = TransactionSigner(
+        btcRegisteredAddressesProvider, btcChangeAddressProvider,
+        btcNetworkConfigProvider
+    )
     val signCollector =
         SignCollector(
             signaturesCollectorCredential,
             signaturesCollectorIrohaConsumer,
             irohaApi,
-            transactionSigner
+            transactionSigner,
+            btcNetworkConfigProvider
         )
 
     private val withdrawalStatistics = WithdrawalStatistics.create()
@@ -232,7 +237,7 @@ class BtcWithdrawalTestEnvironment(
 
         // Checks if transaction output was addressed to available address
         override fun isAvailableOutput(availableAddresses: Set<String>, output: TransactionOutput): Boolean {
-            val btcAddress = outPutToBase58Address(output)
+            val btcAddress = outPutToBase58Address(output, RegTestParams.get())
             return availableAddresses.contains(btcAddress) && !btcAddressBlackList.contains(btcAddress)
         }
     }


### PR DESCRIPTION
### Description of the Change
BitcoinJ uses not suitable network parameters when it loads transactions from the wallet. We must set network parameters manually.