### PR TITLE
Btc network check

### DIFF
--- a/btc-address-generation/src/main/kotlin/com/d3/btc/generation/init/BtcAddressGenerationInitialization.kt
+++ b/btc-address-generation/src/main/kotlin/com/d3/btc/generation/init/BtcAddressGenerationInitialization.kt
@@ -10,7 +10,14 @@ import com.d3.btc.provider.account.BTC_CURRENCY_NAME_KEY
 import com.d3.btc.provider.generation.ADDRESS_GENERATION_NODE_ID_KEY
 import com.d3.btc.provider.generation.ADDRESS_GENERATION_TIME_KEY
 import com.d3.btc.provider.generation.BtcPublicKeyProvider
+import com.d3.btc.provider.network.BtcNetworkConfigProvider
+import com.d3.btc.wallet.checkWalletNetwork
 import com.d3.btc.wallet.safeSave
+import com.d3.commons.sidechain.iroha.CLIENT_DOMAIN
+import com.d3.commons.sidechain.iroha.IrohaChainListener
+import com.d3.commons.sidechain.iroha.util.getAccountDetails
+import com.d3.commons.sidechain.iroha.util.getSetDetailCommands
+import com.d3.commons.util.createPrettySingleThreadPool
 import com.github.kittinunf.result.Result
 import com.github.kittinunf.result.failure
 import com.github.kittinunf.result.flatMap
@@ -25,11 +32,6 @@ import org.bitcoinj.wallet.Wallet
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
-import com.d3.commons.sidechain.iroha.CLIENT_DOMAIN
-import com.d3.commons.sidechain.iroha.IrohaChainListener
-import com.d3.commons.sidechain.iroha.util.getAccountDetails
-import com.d3.commons.sidechain.iroha.util.getSetDetailCommands
-import com.d3.commons.util.createPrettySingleThreadPool
 
 /*
    This class listens to special account to be triggered and starts generation process
@@ -42,7 +44,8 @@ class BtcAddressGenerationInitialization(
     @Autowired private val btcAddressGenerationConfig: BtcAddressGenerationConfig,
     @Autowired private val btcPublicKeyProvider: BtcPublicKeyProvider,
     @Autowired private val irohaChainListener: IrohaChainListener,
-    @Autowired private val addressGenerationTrigger: AddressGenerationTrigger
+    @Autowired private val addressGenerationTrigger: AddressGenerationTrigger,
+    @Autowired private val btcNetworkConfigProvider: BtcNetworkConfigProvider
 ) : HealthyService() {
 
     /*
@@ -50,17 +53,19 @@ class BtcAddressGenerationInitialization(
     If trigger account is triggered, new session account full notary public keys will be created
      */
     fun init(): Result<Unit, Exception> {
-        return irohaChainListener.getBlockObservable()
-            .map { irohaObservable ->
-                initIrohaObservable(irohaObservable)
-            }.flatMap {
-                // Start address generation at initial phase
-                addressGenerationTrigger
-                    .startFreeAddressGenerationIfNeeded(
-                        btcAddressGenerationConfig.threshold,
-                        btcAddressGenerationConfig.nodeId
-                    )
-            }
+        //Check wallet network
+        return keysWallet.checkWalletNetwork(btcNetworkConfigProvider.getConfig()).flatMap {
+            irohaChainListener.getBlockObservable()
+        }.map { irohaObservable ->
+            initIrohaObservable(irohaObservable)
+        }.flatMap {
+            // Start address generation at initial phase
+            addressGenerationTrigger
+                .startFreeAddressGenerationIfNeeded(
+                    btcAddressGenerationConfig.threshold,
+                    btcAddressGenerationConfig.nodeId
+                )
+        }
     }
 
     private fun initIrohaObservable(irohaObservable: Observable<BlockOuterClass.Block>) {

--- a/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/init/BtcWithdrawalInitialization.kt
+++ b/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/init/BtcWithdrawalInitialization.kt
@@ -7,6 +7,7 @@ import com.d3.btc.helper.network.addPeerConnectionStatusListener
 import com.d3.btc.helper.network.startChainDownload
 import com.d3.btc.provider.BtcRegisteredAddressesProvider
 import com.d3.btc.provider.network.BtcNetworkConfigProvider
+import com.d3.btc.wallet.checkWalletNetwork
 import com.d3.btc.withdrawal.BTC_WITHDRAWAL_SERVICE_NAME
 import com.d3.btc.withdrawal.config.withdrawalConfig
 import com.d3.btc.withdrawal.handler.NewFeeRateWasSetHandler
@@ -70,7 +71,10 @@ class BtcWithdrawalInitialization(
     private val btcFeeRateListener = BitcoinBlockChainFeeRateListener(btcFeeRateService)
 
     fun init(): Result<Unit, Exception> {
-        return btcChangeAddressProvider.getChangeAddress().map { changeAddress ->
+        // Check wallet network
+        return transferWallet.checkWalletNetwork(btcNetworkConfigProvider.getConfig()).flatMap {
+            btcChangeAddressProvider.getChangeAddress()
+        }.map { changeAddress ->
             transferWallet.addWatchedAddress(
                 Address.fromBase58(btcNetworkConfigProvider.getConfig(), changeAddress.address)
             )

--- a/btc/src/main/kotlin/com/d3/btc/wallet/WalletExt.kt
+++ b/btc/src/main/kotlin/com/d3/btc/wallet/WalletExt.kt
@@ -1,5 +1,7 @@
 package com.d3.btc.wallet
 
+import com.github.kittinunf.result.Result
+import org.bitcoinj.core.NetworkParameters
 import org.bitcoinj.wallet.Wallet
 import java.io.File
 import java.io.RandomAccessFile
@@ -27,6 +29,25 @@ fun safeLoad(walletPath: String): Wallet {
     var wallet: Wallet? = null
     lockFileApply(walletPath) { wallet = Wallet.loadFromFile(File(walletPath)) }
     return wallet!!
+}
+
+
+/**
+ * Checks wallet network
+ * If wallet network differs from service network [IllegalStateException] will be thrown
+ * @param serviceNetwork - network of service
+ */
+fun Wallet.checkWalletNetwork(
+    serviceNetwork: NetworkParameters
+): Result<Unit, Exception> {
+    return Result.of {
+        if (this.params.id != serviceNetwork.id) {
+            throw IllegalStateException(
+                "Bad wallet network parameters. " +
+                        "Required ${serviceNetwork.id} but found ${this.params.id}"
+            )
+        }
+    }
 }
 
 /**

--- a/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/environment/BtcAddressGenerationTestEnvironment.kt
+++ b/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/environment/BtcAddressGenerationTestEnvironment.kt
@@ -96,6 +96,8 @@ class BtcAddressGenerationTestEnvironment(
         irohaApi
     )
 
+    private val btcNetworkConfigProvider = BtcRegTestConfigProvider()
+
     private val registrationQueryAPI = QueryAPI(
         irohaApi,
         registrationCredential.accountId,
@@ -115,7 +117,7 @@ class BtcAddressGenerationTestEnvironment(
             btcGenerationConfig.changeAddressesStorageAccount,
             multiSigConsumer,
             sessionConsumer,
-            BtcRegTestConfigProvider()
+            btcNetworkConfigProvider
         )
     }
 
@@ -152,7 +154,8 @@ class BtcAddressGenerationTestEnvironment(
         btcGenerationConfig,
         btcPublicKeyProvider(),
         irohaListener,
-        addressGenerationTrigger
+        addressGenerationTrigger,
+        btcNetworkConfigProvider
     )
 
     /**


### PR DESCRIPTION
### Description of the Change
Wrong wallet type may be created accidentally. In order to avoid any problems and money loss, wallet type must be checked before the service start. 