### PR TITLE
Storing generation time in Btc address generation

### DIFF
--- a/btc-registration/src/main/kotlin/com/d3/btc/registration/strategy/BtcRegistrationStrategyImpl.kt
+++ b/btc-registration/src/main/kotlin/com/d3/btc/registration/strategy/BtcRegistrationStrategyImpl.kt
@@ -35,9 +35,10 @@ class BtcRegistrationStrategyImpl(
             if (freeAddresses.isEmpty()) {
                 throw IllegalStateException("no free btc address to register")
             }
-            val freeAddress = freeAddresses.first()
+            // Get the newest address among free addresses
+            val freeAddress = freeAddresses.maxBy { address -> address.info.generationTime ?: 0 }
             irohaBtcAccountCreator.create(
-                freeAddress.address,
+                freeAddress!!.address,
                 whitelist,
                 accountName,
                 domainId,

--- a/btc/src/main/kotlin/com/d3/btc/model/BtcAddress.kt
+++ b/btc/src/main/kotlin/com/d3/btc/model/BtcAddress.kt
@@ -12,17 +12,23 @@ data class BtcAddress(val address: String, val info: AddressInfo)
  * @param irohaClient - address owner Iroha client id
  * @param notaryKeys - keys that were used to create this address
  * @param nodeId - id of node that created this address
+ * @param generationTime - time of address generation
  */
-data class AddressInfo(val irohaClient: String?, val notaryKeys: List<String>, val nodeId: String) {
+data class AddressInfo(
+    val irohaClient: String?,
+    val notaryKeys: List<String>,
+    val nodeId: String,
+    val generationTime: Long?
+) {
 
     fun toJson() = addressInfoJsonAdapter.toJson(this).irohaEscape()
 
     companion object {
         fun fromJson(json: String) = addressInfoJsonAdapter.fromJson(json)
-        fun createFreeAddressInfo(notaryKeys: List<String>, nodeId: String) =
-            AddressInfo(null, notaryKeys, nodeId)
+        fun createFreeAddressInfo(notaryKeys: List<String>, nodeId: String, generationTime: Long) =
+            AddressInfo(null, notaryKeys, nodeId, generationTime)
 
-        fun createChangeAddressInfo(notaryKeys: List<String>, nodeId: String) =
-            AddressInfo(null, notaryKeys, nodeId)
+        fun createChangeAddressInfo(notaryKeys: List<String>, nodeId: String, generationTime: Long) =
+            AddressInfo(null, notaryKeys, nodeId, generationTime)
     }
 }

--- a/btc/src/main/kotlin/com/d3/btc/provider/account/IrohaBtcAccountRegistrator.kt
+++ b/btc/src/main/kotlin/com/d3/btc/provider/account/IrohaBtcAccountRegistrator.kt
@@ -49,7 +49,8 @@ class IrohaBtcAccountRegistrator(
             AddressInfo(
                 "$userName@$domain",
                 notaryKeys,
-                nodeId
+                nodeId,
+                null
             ).toJson()
         }
     }

--- a/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/BtcRegistrationIntegrationTest.kt
+++ b/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/BtcRegistrationIntegrationTest.kt
@@ -53,7 +53,7 @@ class BtcRegistrationIntegrationTest {
         res = btcRegistrationEnvironment.register(userName, keypair.public.toHexString())
         assertEquals(200, res.statusCode)
         val registeredBtcAddress = String(res.content)
-        btcRegistrationEnvironment.btcTakenAddressesProvider.getRegisteredAddresses().fold({ addresses ->
+        btcRegistrationEnvironment.btcRegisteredAddressesProvider.getRegisteredAddresses().fold({ addresses ->
             assertEquals(
                 "$userName@$CLIENT_DOMAIN",
                 addresses.first { btcAddress -> btcAddress.address == registeredBtcAddress }.info.irohaClient
@@ -74,7 +74,7 @@ class BtcRegistrationIntegrationTest {
     @Test
     fun testRegistrationNoAddressForMyNode() {
         val clientsBeforeRegistration =
-            btcRegistrationEnvironment.btcTakenAddressesProvider.getRegisteredAddresses().get().size
+            btcRegistrationEnvironment.btcRegisteredAddressesProvider.getRegisteredAddresses().get().size
         integrationHelper.genFreeBtcAddress(
             btcRegistrationEnvironment.btcAddressGenerationConfig.btcKeysWalletPath,
             "different node id"
@@ -88,7 +88,7 @@ class BtcRegistrationIntegrationTest {
         assertEquals(500, res.statusCode)
         assertEquals(
             clientsBeforeRegistration,
-            btcRegistrationEnvironment.btcTakenAddressesProvider.getRegisteredAddresses().get().size
+            btcRegistrationEnvironment.btcRegisteredAddressesProvider.getRegisteredAddresses().get().size
         )
     }
 
@@ -113,14 +113,17 @@ class BtcRegistrationIntegrationTest {
 
             val keypair = Ed25519Sha3().generateKeypair()
             val userName = String.getRandomString(9)
+            val newestAddress = btcRegistrationEnvironment.btcFreeAddressesProvider.getFreeAddresses().get()
+                .maxBy { address -> address.info.generationTime ?: 0 }!!
             var res = registrationServiceEnvironment.register(userName, keypair.public.toHexString())
             assertEquals(200, res.statusCode)
             res = btcRegistrationEnvironment.register(userName, keypair.public.toHexString())
             assertEquals(200, res.statusCode)
             val registeredBtcAddress = String(res.content)
+            assertEquals(newestAddress.address, registeredBtcAddress)
             assertFalse(takenAddresses.contains(registeredBtcAddress))
             takenAddresses.add(registeredBtcAddress)
-            btcRegistrationEnvironment.btcTakenAddressesProvider.getRegisteredAddresses().fold({ addresses ->
+            btcRegistrationEnvironment.btcRegisteredAddressesProvider.getRegisteredAddresses().fold({ addresses ->
                 assertEquals(
                     "$userName@$CLIENT_DOMAIN",
                     addresses.first { btcAddress -> btcAddress.address == registeredBtcAddress }.info.irohaClient
@@ -147,7 +150,7 @@ class BtcRegistrationIntegrationTest {
     @Test
     fun testRegistrationNoFree() {
         val clientsBeforeRegistration =
-            btcRegistrationEnvironment.btcTakenAddressesProvider.getRegisteredAddresses().get().size
+            btcRegistrationEnvironment.btcRegisteredAddressesProvider.getRegisteredAddresses().get().size
         val keypair = Ed25519Sha3().generateKeypair()
         val userName = String.getRandomString(9)
 
@@ -161,7 +164,7 @@ class BtcRegistrationIntegrationTest {
         assertEquals(500, res.statusCode)
         assertEquals(
             clientsBeforeRegistration,
-            btcRegistrationEnvironment.btcTakenAddressesProvider.getRegisteredAddresses().get().size
+            btcRegistrationEnvironment.btcRegisteredAddressesProvider.getRegisteredAddresses().get().size
         )
     }
 
@@ -174,7 +177,7 @@ class BtcRegistrationIntegrationTest {
     @Test
     fun testRegistrationOnlyChangeAddresses() {
         val clientsBeforeRegistration =
-            btcRegistrationEnvironment.btcTakenAddressesProvider.getRegisteredAddresses().get().size
+            btcRegistrationEnvironment.btcRegisteredAddressesProvider.getRegisteredAddresses().get().size
         integrationHelper.genChangeBtcAddress(btcRegistrationEnvironment.btcAddressGenerationConfig.btcKeysWalletPath)
 
         val num =
@@ -189,7 +192,7 @@ class BtcRegistrationIntegrationTest {
         assertEquals(500, res.statusCode)
         assertEquals(
             clientsBeforeRegistration,
-            btcRegistrationEnvironment.btcTakenAddressesProvider.getRegisteredAddresses().get().size
+            btcRegistrationEnvironment.btcRegisteredAddressesProvider.getRegisteredAddresses().get().size
         )
     }
 }

--- a/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/environment/BtcRegistrationTestEnvironment.kt
+++ b/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/environment/BtcRegistrationTestEnvironment.kt
@@ -36,13 +36,15 @@ class BtcRegistrationTestEnvironment(private val integrationHelper: BtcIntegrati
 
     private val btcClientCreatorConsumer = IrohaConsumerImpl(btcRegistrationCredential, integrationHelper.irohaAPI)
 
+    val btcFreeAddressesProvider = BtcFreeAddressesProvider(
+        btcRegistrationConfig.nodeId, btcAddressesProvider(),
+        btcRegisteredAddressesProvider()
+    )
+
     val btcRegistrationServiceInitialization = BtcRegistrationServiceInitialization(
         btcRegistrationConfig,
         BtcRegistrationStrategyImpl(
-            BtcFreeAddressesProvider(
-                btcRegistrationConfig.nodeId, btcAddressesProvider(),
-                btcRegisteredAddressesProvider()
-            ),
+            btcFreeAddressesProvider,
             irohaBtcAccountCreator()
         )
     )
@@ -70,7 +72,7 @@ class BtcRegistrationTestEnvironment(private val integrationHelper: BtcIntegrati
         )
     }
 
-    val btcTakenAddressesProvider = BtcRegisteredAddressesProvider(
+    val btcRegisteredAddressesProvider = BtcRegisteredAddressesProvider(
         integrationHelper.queryAPI,
         btcRegistrationConfig.registrationCredential.accountId,
         integrationHelper.accountHelper.notaryAccount.accountId

--- a/notary-btc-integration-test/src/main/kotlin/integration/helper/BtcIntegrationHelperUtil.kt
+++ b/notary-btc-integration-test/src/main/kotlin/integration/helper/BtcIntegrationHelperUtil.kt
@@ -124,7 +124,11 @@ class BtcIntegrationHelperUtil(peers: Int = 1) : IrohaIntegrationHelperUtil(peer
                     IrohaCommand.CommandSetAccountDetail(
                         accountHelper.notaryAccount.accountId,
                         address.toBase58(),
-                        AddressInfo.createFreeAddressInfo(listOf(key.publicKeyAsHex), NODE_ID).toJson()
+                        AddressInfo.createFreeAddressInfo(
+                            listOf(key.publicKeyAsHex),
+                            NODE_ID,
+                            System.currentTimeMillis()
+                        ).toJson()
                     )
                 )
             )
@@ -158,7 +162,7 @@ class BtcIntegrationHelperUtil(peers: Int = 1) : IrohaIntegrationHelperUtil(peer
             mstRegistrationIrohaConsumer,
             accountHelper.notaryAccount.accountId,
             address.toBase58(),
-            AddressInfo.createFreeAddressInfo(listOf(key.publicKeyAsHex), nodeId).toJson()
+            AddressInfo.createFreeAddressInfo(listOf(key.publicKeyAsHex), nodeId, System.currentTimeMillis()).toJson()
         ).map { address }
     }
 
@@ -173,7 +177,11 @@ class BtcIntegrationHelperUtil(peers: Int = 1) : IrohaIntegrationHelperUtil(peer
             mstRegistrationIrohaConsumer,
             accountHelper.changeAddressesStorageAccount.accountId,
             address.toBase58(),
-            AddressInfo.createChangeAddressInfo(listOf(key.publicKeyAsHex), NODE_ID).toJson()
+            AddressInfo.createChangeAddressInfo(
+                listOf(key.publicKeyAsHex),
+                NODE_ID,
+                System.currentTimeMillis()
+            ).toJson()
         ).map { address }
     }
 


### PR DESCRIPTION
### Description of the Change
Now we store generation time inside Bitcoin MultiSig address details. We can use it to block out-of-date addresses. Currently, this value is used to pick the newest address among free to register addresses.