### PR TITLE
Fixed quorum

### DIFF
--- a/btc-deposit/README.md
+++ b/btc-deposit/README.md
@@ -7,7 +7,7 @@ Bitcoin Deposit service(or simply `btc-deposit`) is here to listen to Bitcoin bl
 2) Start Bitcoin blockchain downloading process (only headers are stored on disk)
 3) Increase client balance in Iroha blockchain if needed. This 'increase' works in a multisignature fashion. So every node must create the same Iroha transaction. Bitcoin block time is used as a source of time of Iroha 'increase balance' transaction. Doing that we can guarantee that every node will use the same time.
 
-### Configuration overview (btc-deposit.properties)
+### Configuration overview (deposit.properties)
 * `btc-deposit.registrationAccount` - this account stores registered Bitcoin addresses associated with D3 clients. This information is used to check if a Bitcoin transaction is related to our clients.
 
 * `btc-deposit.healthCheckPort` - port of health check endpoint. A health check is available on `http://host:healthCheckPort/health`. This service checks if `btc-deposit` is connected to one Bitcoin peer at least.

--- a/btc-deposit/src/main/kotlin/com/d3/btc/deposit/config/BtcDepositConfig.kt
+++ b/btc-deposit/src/main/kotlin/com/d3/btc/deposit/config/BtcDepositConfig.kt
@@ -15,12 +15,6 @@ interface BtcDepositConfig {
 
     val notaryCredential: IrohaCredentialConfig
 
-    /** Iroha account to store notary peer list  */
-    val notaryListStorageAccount: String
-
-    /** Iroha account to set notary peer list */
-    val notaryListSetterAccount: String
-
     val registrationAccount: String
 
     val btcTransferWalletPath: String

--- a/btc-deposit/src/main/kotlin/com/d3/btc/deposit/config/BtcNotaryAppConfiguration.kt
+++ b/btc-deposit/src/main/kotlin/com/d3/btc/deposit/config/BtcNotaryAppConfiguration.kt
@@ -40,13 +40,6 @@ class BtcNotaryAppConfiguration {
     fun queryAPI() = QueryAPI(irohaAPI(), notaryCredential.accountId, notaryKeypair)
 
     @Bean
-    fun peerListProvider() = NotaryPeerListProviderImpl(
-        queryAPI(),
-        depositConfig.notaryListStorageAccount,
-        depositConfig.notaryListSetterAccount
-    )
-
-    @Bean
     fun btcEventsSource(): PublishSubject<SideChainEvent.PrimaryBlockChainEvent> {
         return PublishSubject.create<SideChainEvent.PrimaryBlockChainEvent>()
     }
@@ -57,7 +50,7 @@ class BtcNotaryAppConfiguration {
     }
 
     @Bean
-    fun notary() = NotaryImpl(notaryCredential, irohaAPI(), btcEventsObservable(), peerListProvider())
+    fun notary() = NotaryImpl(notaryCredential, irohaAPI(), btcEventsObservable())
 
     @Bean
     fun notaryConfig() = depositConfig

--- a/btc-dw-bridge/src/main/kotlin/com/d3/btc/dwbridge/config/BtcDWBridgeAppConfiguration.kt
+++ b/btc-dw-bridge/src/main/kotlin/com/d3/btc/dwbridge/config/BtcDWBridgeAppConfiguration.kt
@@ -85,13 +85,6 @@ class BtcDWBridgeAppConfiguration {
     fun queryAPI() = QueryAPI(irohaAPI(), notaryCredential.accountId, notaryKeypair)
 
     @Bean
-    fun peerListProvider() = NotaryPeerListProviderImpl(
-        queryAPI(),
-        depositConfig.notaryListStorageAccount,
-        depositConfig.notaryListSetterAccount
-    )
-
-    @Bean
     fun btcEventsSource(): PublishSubject<SideChainEvent.PrimaryBlockChainEvent> {
         return PublishSubject.create<SideChainEvent.PrimaryBlockChainEvent>()
     }
@@ -102,7 +95,7 @@ class BtcDWBridgeAppConfiguration {
     }
 
     @Bean
-    fun notary() = NotaryImpl(notaryCredential, irohaAPI(), btcEventsObservable(), peerListProvider())
+    fun notary() = NotaryImpl(notaryCredential, irohaAPI(), btcEventsObservable())
 
     @Bean
     fun rmqConfig() = rmqConfig

--- a/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/handler/NewTransferHandler.kt
+++ b/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/handler/NewTransferHandler.kt
@@ -95,7 +95,7 @@ class NewTransferHandler(
      */
     private fun startConsensusProcess(withdrawalDetails: WithdrawalDetails) {
         withdrawalConsensusProvider.createConsensusData(withdrawalDetails).fold({
-            logger.info("Consensus data for $withdrawalDetails has beenl created")
+            logger.info("Consensus data for $withdrawalDetails has been created")
         }, { ex ->
             logger.error("Cannot create consensus for withdrawal $withdrawalDetails", ex)
             btcRollbackService.rollback(withdrawalDetails, "Cannot create consensus")

--- a/btc/src/main/kotlin/com/d3/btc/provider/generation/BtcPublicKeyProvider.kt
+++ b/btc/src/main/kotlin/com/d3/btc/provider/generation/BtcPublicKeyProvider.kt
@@ -7,6 +7,7 @@ import com.d3.btc.provider.network.BtcNetworkConfigProvider
 import com.d3.commons.provider.NotaryPeerListProvider
 import com.d3.commons.sidechain.iroha.consumer.IrohaConsumer
 import com.d3.commons.sidechain.iroha.util.ModelUtil
+import com.d3.commons.sidechain.iroha.util.getAccountQuorum
 import com.d3.commons.util.getRandomId
 import com.github.kittinunf.result.Result
 import com.github.kittinunf.result.map
@@ -83,7 +84,7 @@ class BtcPublicKeyProvider(
         nodeId: String,
         onMsAddressCreated: () -> Unit
     ): Result<Unit, Exception> {
-        return Result.of {
+        return multiSigConsumer.getConsumerQuorum().map { quorum ->
             val peers = notaryPeerListProvider.getPeerList().size
             if (peers == 0) {
                 throw IllegalStateException("No peers to create btc multisignature address")
@@ -92,15 +93,15 @@ class BtcPublicKeyProvider(
                     "Not enough keys are collected to generate a multisig address(${notaryKeys.size}" +
                             " out of $peers)"
                 }
-                return@of
+                return@map
             } else if (!hasMyKey(notaryKeys)) {
                 logger.info { "Cannot be involved in address generation. No access to $notaryKeys." }
-                return@of
+                return@map
             }
             val msAddress = createMsAddress(notaryKeys, btcNetworkConfigProvider.getConfig())
             if (keysWallet.isAddressWatched(msAddress)) {
                 logger.info("Address $msAddress has been already created")
-                return@of
+                return@map
             } else if (!keysWallet.addWatchedAddress(msAddress)) {
                 throw IllegalStateException("BTC address $msAddress was not added to wallet")
             }
@@ -113,10 +114,10 @@ class BtcPublicKeyProvider(
                 msAddress.toBase58(),
                 addressStorage.addressInfo.toJson(),
                 generationTime,
-                quorum = peers
+                quorum
             ).fold({
                 logger.info { "New BTC ${addressType.title} address $msAddress was created. Node id '$nodeId'" }
-            }, { ex -> throw ex })
+            }, { ex -> throw Exception("Cannot create Bitcoin multisig address", ex) })
         }
     }
 

--- a/configs/btc/deposit_local.properties
+++ b/configs/btc/deposit_local.properties
@@ -1,7 +1,5 @@
 # ========= Bitcoin Deposit =========
 btc-deposit.registrationAccount=btc_registration_service@notary
-btc-deposit.notaryListStorageAccount=notaries@notary
-btc-deposit.notaryListSetterAccount=notary@notary
 btc-deposit.healthCheckPort=7070
 btc-deposit.btcTransferWalletPath=deploy/bitcoin/regtest/transfers.d3.wallet
 # --------- Credentials ------- 

--- a/configs/btc/deposit_mainnet.properties
+++ b/configs/btc/deposit_mainnet.properties
@@ -1,7 +1,5 @@
 # ========= Bitcoin Deposit =========
 btc-deposit.registrationAccount=btc_registration_service@notary
-btc-deposit.notaryListStorageAccount=notaries@notary
-btc-deposit.notaryListSetterAccount=notary@notary
 btc-deposit.healthCheckPort=7070
 btc-deposit.btcTransferWalletPath=deploy/bitcoin/mainnet/transfers.d3.wallet
 # --------- Credentials -------

--- a/configs/btc/deposit_testnet.properties
+++ b/configs/btc/deposit_testnet.properties
@@ -1,7 +1,5 @@
 # ========= Bitcoin Deposit =========
 btc-deposit.registrationAccount=btc_registration_service@notary
-btc-deposit.notaryListStorageAccount=notaries@notary
-btc-deposit.notaryListSetterAccount=notary@notary
 btc-deposit.healthCheckPort=7070
 btc-deposit.btcTransferWalletPath=deploy/bitcoin/testnet/transfers.d3.wallet
 # --------- Credentials -------

--- a/configs/eth/deposit_local.properties
+++ b/configs/eth/deposit_local.properties
@@ -2,8 +2,6 @@
 eth-deposit.registrationServiceIrohaAccount=eth_registration_service@notary
 eth-deposit.tokenStorageAccount=eth_token_storage_service@notary
 eth-deposit.tokenSetterAccount=eth_token_storage_service@notary
-eth-deposit.notaryListStorageAccount=notaries@notary
-eth-deposit.notaryListSetterAccount=notary@notary
 eth-deposit.whitelistSetter=eth_registration_service@notary
 # --------- Credentials -------
 eth-deposit.notaryCredential.accountId=notary@notary

--- a/configs/eth/deposit_mainnet.properties
+++ b/configs/eth/deposit_mainnet.properties
@@ -2,8 +2,6 @@
 eth-deposit.registrationServiceIrohaAccount=eth_registration_service@notary
 eth-deposit.tokenStorageAccount=eth_token_storage_service@notary
 eth-deposit.tokenSetterAccount=eth_token_storage_service@notary
-eth-deposit.notaryListStorageAccount=notaries@notary
-eth-deposit.notaryListSetterAccount=notary@notary
 eth-deposit.whitelistSetter=eth_registration_service@notary
 # --------- Credentials -------
 eth-deposit.notaryCredential.accountId=notary@notary

--- a/configs/eth/deposit_testnet.properties
+++ b/configs/eth/deposit_testnet.properties
@@ -2,8 +2,6 @@
 eth-deposit.registrationServiceIrohaAccount=eth_registration_service@notary
 eth-deposit.tokenStorageAccount=eth_token_storage_service@notary
 eth-deposit.tokenSetterAccount=eth_token_storage_service@notary
-eth-deposit.notaryListStorageAccount=notaries@notary
-eth-deposit.notaryListSetterAccount=notary@notary
 eth-deposit.whitelistSetter=eth_registration_service@notary
 # --------- Credentials -------
 eth-deposit.notaryCredential.accountId=notary@notary

--- a/eth/src/main/kotlin/com/d3/eth/deposit/EthDepositConfig.kt
+++ b/eth/src/main/kotlin/com/d3/eth/deposit/EthDepositConfig.kt
@@ -23,12 +23,6 @@ interface EthDepositConfig {
     /** Iroha account that set whitelist for client */
     val whitelistSetter: String
 
-    /** Iroha account to store notary peer list  */
-    val notaryListStorageAccount: String
-
-    /** Iroha account to set notary peer list */
-    val notaryListSetterAccount: String
-
     val notaryCredential: IrohaCredentialConfig
 
     val refund: RefundConfig

--- a/eth/src/main/kotlin/com/d3/eth/deposit/EthDepositInitialization.kt
+++ b/eth/src/main/kotlin/com/d3/eth/deposit/EthDepositInitialization.kt
@@ -5,7 +5,6 @@ import com.d3.commons.model.IrohaCredential
 import com.d3.commons.notary.Notary
 import com.d3.commons.notary.NotaryImpl
 import com.d3.commons.notary.endpoint.ServerInitializationBundle
-import com.d3.commons.provider.NotaryPeerListProviderImpl
 import com.d3.commons.sidechain.SideChainEvent
 import com.d3.commons.util.createPrettyScheduledThreadPool
 import com.d3.eth.deposit.endpoint.EthRefundStrategyImpl
@@ -21,7 +20,6 @@ import com.github.kittinunf.result.map
 import io.reactivex.Observable
 import iroha.protocol.Primitive
 import jp.co.soramitsu.iroha.java.IrohaAPI
-import jp.co.soramitsu.iroha.java.QueryAPI
 import jp.co.soramitsu.iroha.java.Transaction
 import mu.KLogging
 import okhttp3.OkHttpClient
@@ -102,15 +100,7 @@ class EthDepositInitialization(
                 .build()
         )
 
-        val queryAPI = QueryAPI(irohaAPI, notaryCredential.accountId, notaryCredential.keyPair)
-
-        val peerListProvider = NotaryPeerListProviderImpl(
-            queryAPI,
-            ethDepositConfig.notaryListStorageAccount,
-            ethDepositConfig.notaryListSetterAccount
-        )
-
-        return NotaryImpl(notaryCredential, irohaAPI, ethEvents, peerListProvider)
+        return NotaryImpl(notaryCredential, irohaAPI, ethEvents)
     }
 
     /**

--- a/eth/src/test/kotlin/com/d3/commons/notary/NotaryTest.kt
+++ b/eth/src/test/kotlin/com/d3/commons/notary/NotaryTest.kt
@@ -1,13 +1,8 @@
 package com.d3.commons.notary
 
-import com.d3.commons.config.IrohaConfig
-import com.d3.commons.config.IrohaCredentialConfig
 import com.d3.commons.model.IrohaCredential
-import com.d3.commons.provider.NotaryPeerListProvider
 import com.d3.commons.sidechain.SideChainEvent
 import com.d3.commons.sidechain.iroha.util.ModelUtil
-import com.d3.eth.deposit.EthDepositConfig
-import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
 import io.reactivex.Observable
 import io.reactivex.observers.TestObserver
@@ -22,30 +17,8 @@ import kotlin.test.assertEquals
  */
 class NotaryTest {
 
-    /** Configuration for Iroha */
-    private val irohaConfig = mock<IrohaConfig>() {
-        on { port } doReturn 8080
-        on { hostname } doReturn "localhost"
-    }
-
-    private val credentialConfig = mock<IrohaCredentialConfig>() {
-        on { privkeyPath } doReturn "deploy/iroha/keys/test@notary.priv"
-        on { pubkeyPath } doReturn "deploy/iroha/keys/test@notary.pub"
-        on { accountId } doReturn "creator@iroha"
-    }
-
     private val irohaCredential = IrohaCredential("creator@iroha", ModelUtil.generateKeypair())
     private val irohaAPI = mock<IrohaAPI>()
-
-    /** Configuration for notary */
-    private val notaryConfig = mock<EthDepositConfig>() {
-        on { iroha } doReturn irohaConfig
-        on { notaryListStorageAccount } doReturn "listener@notary"
-        on { notaryListSetterAccount } doReturn "setter@notary"
-        on { notaryCredential } doReturn credentialConfig
-    }
-
-    private val peerListProvider = mock<NotaryPeerListProvider>()
 
     init {
         try {
@@ -149,7 +122,7 @@ class NotaryTest {
 
         // source of events from side chains
         val obsEth = Observable.just<SideChainEvent.PrimaryBlockChainEvent>(custodianIntention)
-        val notary = NotaryImpl(irohaCredential, irohaAPI, obsEth, peerListProvider)
+        val notary = NotaryImpl(irohaCredential, irohaAPI, obsEth)
         val res = notary.irohaOutput()
         checkEthereumDepositResult(
             expectedAmount,
@@ -190,7 +163,7 @@ class NotaryTest {
 
         // source of events from side chains
         val obsEth = Observable.just<SideChainEvent.PrimaryBlockChainEvent>(custodianIntention)
-        val notary = NotaryImpl(irohaCredential, irohaAPI, obsEth, peerListProvider)
+        val notary = NotaryImpl(irohaCredential, irohaAPI, obsEth)
         val res = notary.irohaOutput()
         checkEthereumDepositResult(
             expectedAmount,

--- a/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/environment/BtcNotaryTestEnvironment.kt
+++ b/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/environment/BtcNotaryTestEnvironment.kt
@@ -13,7 +13,6 @@ import com.d3.btc.provider.network.BtcRegTestConfigProvider
 import com.d3.commons.config.BitcoinConfig
 import com.d3.commons.model.IrohaCredential
 import com.d3.commons.notary.NotaryImpl
-import com.d3.commons.provider.NotaryPeerListProviderImpl
 import com.d3.commons.sidechain.SideChainEvent
 import com.d3.commons.sidechain.iroha.IrohaChainListener
 import com.d3.commons.sidechain.iroha.util.ModelUtil
@@ -87,17 +86,11 @@ class BtcNotaryTestEnvironment(
     private val confidenceExecutorService =
         createPrettySingleThreadPool(BTC_DEPOSIT_SERVICE_NAME, "tx-confidence-listener")
 
-    private val peerListProvider = NotaryPeerListProviderImpl(
-        queryAPI,
-        depositConfig.notaryListStorageAccount,
-        depositConfig.notaryListSetterAccount
-    )
-
     private val btcEventsSource = PublishSubject.create<SideChainEvent.PrimaryBlockChainEvent>()
 
     private val btcEventsObservable: Observable<SideChainEvent.PrimaryBlockChainEvent> = btcEventsSource
 
-    private val notary = NotaryImpl(notaryCredential, irohaAPI, btcEventsObservable, peerListProvider)
+    private val notary = NotaryImpl(notaryCredential, irohaAPI, btcEventsObservable)
 
     private val btcWalletListenerRestartService by lazy {
         BtcWalletListenerRestartService(

--- a/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/environment/BtcWithdrawalTestEnvironment.kt
+++ b/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/environment/BtcWithdrawalTestEnvironment.kt
@@ -189,7 +189,7 @@ class BtcWithdrawalTestEnvironment(
         btcWithdrawalConfig.notaryListSetterAccount
     )
     private val btcRollbackService =
-        BtcRollbackService(withdrawalIrohaConsumer, notaryPeerListProvider)
+        BtcRollbackService(withdrawalIrohaConsumer)
     val unsignedTransactions = UnsignedTransactions(signCollector)
     private val withdrawalConsensusProvider = WithdrawalConsensusProvider(
         btcConsensusCredential,

--- a/notary-btc-integration-test/src/main/kotlin/integration/helper/BtcConfigHelper.kt
+++ b/notary-btc-integration-test/src/main/kotlin/integration/helper/BtcConfigHelper.kt
@@ -115,8 +115,6 @@ class BtcConfigHelper(
             override val registrationAccount = accountHelper.registrationAccount.accountId
             override val iroha = createIrohaConfig()
             override val bitcoin = createBitcoinConfig(btcDepositConfig.bitcoin, testName)
-            override val notaryListStorageAccount = accountHelper.notaryListStorageAccount.accountId
-            override val notaryListSetterAccount = accountHelper.notaryListSetterAccount.accountId
             override val notaryCredential = accountHelper.createCredentialConfig(notaryIrohaCredential)
         }
     }

--- a/notary-commons/src/main/kotlin/com/d3/commons/sidechain/iroha/consumer/IrohaConsumer.kt
+++ b/notary-commons/src/main/kotlin/com/d3/commons/sidechain/iroha/consumer/IrohaConsumer.kt
@@ -14,6 +14,11 @@ interface IrohaConsumer {
     val creator: String
 
     /**
+     * Returns consumer quorum value
+     */
+    fun getConsumerQuorum(): Result<Int, Exception>
+
+    /**
      * Send transaction to Iroha and check if it is committed
      * @param utx - unsigned transaction to sign and send
      */

--- a/notary-commons/src/main/kotlin/com/d3/commons/sidechain/iroha/consumer/IrohaConsumerImpl.kt
+++ b/notary-commons/src/main/kotlin/com/d3/commons/sidechain/iroha/consumer/IrohaConsumerImpl.kt
@@ -53,9 +53,7 @@ class IrohaConsumerImpl(
 
     /**
      * Send transaction to Iroha and check if it is committed
-     * @param utx queryResponse ->
-    val stringBuilder = StringBuilder(queryResponse.account.jsonData)
-    Parser().parse(stringBuilder) as JsonObject - unsigned transaction to send
+     * @param utx - unsigned transaction to send
      * @return hex representation of hash or failure
      */
     override fun send(utx: Transaction): Result<String, Exception> {

--- a/notary-commons/src/main/kotlin/com/d3/commons/sidechain/iroha/consumer/IrohaConsumerImpl.kt
+++ b/notary-commons/src/main/kotlin/com/d3/commons/sidechain/iroha/consumer/IrohaConsumerImpl.kt
@@ -1,15 +1,13 @@
 package com.d3.commons.sidechain.iroha.consumer
 
 import com.d3.commons.model.IrohaCredential
+import com.d3.commons.sidechain.iroha.util.getAccountQuorum
 import com.d3.commons.util.hex
 import com.github.kittinunf.result.Result
 import com.github.kittinunf.result.flatMap
 import iroha.protocol.Endpoint
 import iroha.protocol.TransactionOuterClass
-import jp.co.soramitsu.iroha.java.IrohaAPI
-import jp.co.soramitsu.iroha.java.Transaction
-import jp.co.soramitsu.iroha.java.TransactionStatusObserver
-import jp.co.soramitsu.iroha.java.Utils
+import jp.co.soramitsu.iroha.java.*
 import jp.co.soramitsu.iroha.java.detail.BuildableAndSignable
 import jp.co.soramitsu.iroha.java.detail.InlineTransactionStatusObserver
 import jp.co.soramitsu.iroha.java.subscription.WaitForTerminalStatus
@@ -45,13 +43,19 @@ class IrohaConsumerImpl(
     private val irohaAPI: IrohaAPI
 ) : IrohaConsumer {
 
+    private val queryAPI = QueryAPI(irohaAPI, irohaCredential.accountId, irohaCredential.keyPair)
+
     override val creator = irohaCredential.accountId
 
-    val keypair = irohaCredential.keyPair
+    private val keypair = irohaCredential.keyPair
+
+    override fun getConsumerQuorum() = getAccountQuorum(queryAPI, creator)
 
     /**
      * Send transaction to Iroha and check if it is committed
-     * @param utx - unsigned transaction to send
+     * @param utx queryResponse ->
+    val stringBuilder = StringBuilder(queryResponse.account.jsonData)
+    Parser().parse(stringBuilder) as JsonObject - unsigned transaction to send
      * @return hex representation of hash or failure
      */
     override fun send(utx: Transaction): Result<String, Exception> {

--- a/notary-commons/src/main/kotlin/com/d3/commons/sidechain/iroha/util/RequestHelper.kt
+++ b/notary-commons/src/main/kotlin/com/d3/commons/sidechain/iroha/util/RequestHelper.kt
@@ -132,6 +132,22 @@ fun getErrorMessage(errorResponse: QryResponses.ErrorResponse) =
 
 
 /**
+ * Retrieves account quorum from Iroha
+ * @param queryAPI - iroha queries network layer
+ * @param acc - account to read quorum from
+ * @return account quorum
+ */
+fun getAccountQuorum(
+    queryAPI: QueryAPI,
+    acc: String
+): Result<Int, Exception> {
+    return Result.of { getAccount(queryAPI, acc) }
+        .map { queryResponse ->
+            queryResponse.account.quorum
+        }
+}
+
+/**
  * Retrieves account details by setter from Iroha
  * @param queryAPI - iroha queries network layer
  * @param acc - account to read details from

--- a/notary-eth-integration-test/src/main/kotlin/integration/helper/EthConfigHelper.kt
+++ b/notary-eth-integration-test/src/main/kotlin/integration/helper/EthConfigHelper.kt
@@ -101,8 +101,6 @@ open class EthConfigHelper(
             override val registrationServiceIrohaAccount = accountHelper.registrationAccount.accountId
             override val tokenStorageAccount = accountHelper.tokenStorageAccount.accountId
             override val tokenSetterAccount = accountHelper.tokenSetterAccount.accountId
-            override val notaryListStorageAccount = accountHelper.notaryListStorageAccount.accountId
-            override val notaryListSetterAccount = accountHelper.notaryListSetterAccount.accountId
             override val whitelistSetter = accountHelper.registrationAccount.accountId
             override val notaryCredential = notaryCredential_
             override val refund = createRefundConfig()


### PR DESCRIPTION
### Description of the Change
Quorum value must be taken from Iroha account, not from `peerListProvider` because it returns the number of peers. Given that fact, `peerListProvider` is not needed in deposit services.
