### PR TITLE
Refactored configs, primary working with ENV

### DIFF
--- a/notary-commons/build.gradle
+++ b/notary-commons/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     compile group: 'com.github.kittinunf.result', name: 'result', version: '1.4.0'
 
     // Configuration
-    compile group: 'com.jdiazcano.cfg4k', name: 'cfg4k-core', version: '0.9.0'
+    compile group: 'com.jdiazcano.cfg4k', name: 'cfg4k-core', version: '0.9.3'
 
     compile "com.rabbitmq:amqp-client:5.6.0"
 

--- a/notary-commons/src/test/kotlin/com/d3/commons/config/ConfigsPriorityTest.kt
+++ b/notary-commons/src/test/kotlin/com/d3/commons/config/ConfigsPriorityTest.kt
@@ -78,6 +78,43 @@ class ConfigsPriorityTest {
         assertEquals(testConfig.testCredentialConfig.privkeyPath, mixedConfig.testCredentialConfig.privkeyPath)
     }
 
+    /**
+     * @given environment variables containing test properties
+     * @when wrong test properties file is passed to loadConfigs
+     * @then EnvConfig is constructed based on environment variables values
+     */
+    @Test
+    fun testTestConfigEnv() {
+        val testConfig = loadConfigs("test", TestConfig::class.java, "/test.properties").get()
+        environmentVariables.set("ENV_ETHTESTACCOUNT", testConfig.ethTestAccount)
+        environmentVariables.set("ENV_IROHA", "")
+        environmentVariables.set("ENV_IROHA_HOSTNAME", testConfig.iroha.hostname)
+        environmentVariables.set("ENV_IROHA_PORT", testConfig.iroha.port.toString())
+        environmentVariables.set("ENV_ETHEREUM", "")
+        environmentVariables.set("ENV_ETHEREUM_URL", testConfig.ethereum.url)
+        environmentVariables.set("ENV_ETHEREUM_CONFIRMATIONPERIOD", testConfig.ethereum.confirmationPeriod.toString())
+        environmentVariables.set("ENV_ETHEREUM_CREDENTIALSPATH", testConfig.ethereum.credentialsPath)
+        environmentVariables.set("ENV_ETHEREUM_GASPRICE", testConfig.ethereum.gasPrice.toString())
+        environmentVariables.set("ENV_ETHEREUM_GASLIMIT", testConfig.ethereum.gasLimit.toString())
+        environmentVariables.set("ENV_TESTCREDENTIALCONFIG", "")
+        environmentVariables.set("ENV_TESTCREDENTIALCONFIG_ACCOUNTID", testConfig.testCredentialConfig.accountId)
+        environmentVariables.set("ENV_TESTCREDENTIALCONFIG_PUBKEYPATH", testConfig.testCredentialConfig.pubkeyPath)
+        environmentVariables.set("ENV_TESTCREDENTIALCONFIG_PRIVKEYPATH", testConfig.testCredentialConfig.privkeyPath)
+        // Pass an nonexistent file to be sure all values are loaded from the environment
+        val envConfig = loadConfigs("env", TestConfig::class.java, "/NOSUCHFILE.properties").get()
+        assertEquals(testConfig.ethTestAccount, envConfig.ethTestAccount)
+        assertEquals(testConfig.iroha.hostname, envConfig.iroha.hostname)
+        assertEquals(testConfig.iroha.port, envConfig.iroha.port)
+        assertEquals(testConfig.ethereum.url, envConfig.ethereum.url)
+        assertEquals(testConfig.ethereum.confirmationPeriod, envConfig.ethereum.confirmationPeriod)
+        assertEquals(testConfig.ethereum.credentialsPath, envConfig.ethereum.credentialsPath)
+        assertEquals(testConfig.ethereum.gasPrice, envConfig.ethereum.gasPrice)
+        assertEquals(testConfig.ethereum.gasLimit, envConfig.ethereum.gasLimit)
+        assertEquals(testConfig.testCredentialConfig.accountId, envConfig.testCredentialConfig.accountId)
+        assertEquals(testConfig.testCredentialConfig.pubkeyPath, envConfig.testCredentialConfig.pubkeyPath)
+        assertEquals(testConfig.testCredentialConfig.privkeyPath, envConfig.testCredentialConfig.privkeyPath)
+    }
+
     private fun setEthEnvVariables() {
         environmentVariables.set(ETH_CREDENTIALS_PASSWORD_ENV, "env_credentialsPassword")
         environmentVariables.set(ETH_NODE_LOGIN_ENV, "env_nodeLogin")


### PR DESCRIPTION
<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * Jenkins builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->


### Description of the Change
Now we can ignore files and use configs based only on the ENV, but there is an issue we need to include each intermediate node to the variables as well (see in the test). Created an issue https://github.com/jdiazcano/cfg4k/issues/57

### Usage Examples or Tests *[optional]*

