### PR TITLE
Added nonexistent accounts key checking

### DIFF
--- a/bootstrap/src/main/kotlin/jp/co/soramitsu/bootstrap/dto/GenesisBlockModel.kt
+++ b/bootstrap/src/main/kotlin/jp/co/soramitsu/bootstrap/dto/GenesisBlockModel.kt
@@ -25,6 +25,7 @@ data class NeededAccountsResponse(val accounts: List<AccountPrototype> = emptyLi
         this.message = message
     }
 }
+
 /**
  * Accounts which should have quorum 2/3 of peers
  */
@@ -38,7 +39,7 @@ class PeersCountDependentAccountPrototype(
     domainId,
     roles,
     details,
-    passive = false,
+    type = AccountType.ACTIVE,
     quorum = 1,
     peersDependentQuorum = true
 )
@@ -57,7 +58,7 @@ class PassiveAccountPrototype(
     domainId,
     roles,
     details,
-    passive = true,
+    type = AccountType.PASSIVE,
     quorum = quorum
 ) {
 
@@ -73,13 +74,35 @@ class PassiveAccountPrototype(
     }
 }
 
+/**
+ * Accounts that is not reflected in genesis block, only corresponding keypair should be
+ */
+class NoAccountPrototype(
+    name: String? = null,
+    domainId: String? = null
+) : AccountPrototype(
+    name,
+    domainId,
+    emptyList(),
+    emptyMap(),
+    type = AccountType.IGNORED,
+    quorum = 1
+) {
+    override fun createAccount(
+        builder: TransactionBuilder,
+        publicKey: String
+    ) {
+        /* do nothing */
+    }
+}
+
 
 open class AccountPrototype(
     val name: String? = null,
     val domainId: String? = null,
     val roles: List<String> = listOf(),
     val details: Map<String, String> = mapOf(),
-    val passive: Boolean = false,
+    val type: AccountType = AccountType.ACTIVE,
     var quorum: Int = 1,
     val peersDependentQuorum: Boolean = false
 ) {
@@ -93,4 +116,10 @@ open class AccountPrototype(
         roles.forEach { builder.appendRole(id, it) }
         details.forEach { k, v -> builder.setAccountDetail(id, k, v) }
     }
+}
+
+enum class AccountType {
+    ACTIVE,
+    PASSIVE,
+    IGNORED
 }

--- a/bootstrap/src/main/kotlin/jp/co/soramitsu/bootstrap/genesis/d3/D3TestContext.kt
+++ b/bootstrap/src/main/kotlin/jp/co/soramitsu/bootstrap/genesis/d3/D3TestContext.kt
@@ -2,10 +2,11 @@ package jp.co.soramitsu.bootstrap.genesis.d3
 
 import iroha.protocol.Primitive
 import jp.co.soramitsu.bootstrap.changelog.ChangelogInterface
-import jp.co.soramitsu.iroha.java.TransactionBuilder
 import jp.co.soramitsu.bootstrap.dto.AccountPrototype
+import jp.co.soramitsu.bootstrap.dto.NoAccountPrototype
 import jp.co.soramitsu.bootstrap.dto.PassiveAccountPrototype
 import jp.co.soramitsu.bootstrap.dto.PeersCountDependentAccountPrototype
+import jp.co.soramitsu.iroha.java.TransactionBuilder
 
 object D3TestContext {
 
@@ -95,7 +96,8 @@ object D3TestContext {
         AccountPrototype("admin", "notary", listOf("admin")),
         AccountPrototype("sora", "sora", listOf("sora")),
         AccountPrototype("brvs", "brvs"),
-        PassiveAccountPrototype("client_account", "notary")
+        PassiveAccountPrototype("client_account", "notary"),
+        NoAccountPrototype("registration_service_primary", "notary")
     )
 
 

--- a/bootstrap/src/main/kotlin/jp/co/soramitsu/bootstrap/genesis/d3/D3TestGenesisFactory.kt
+++ b/bootstrap/src/main/kotlin/jp/co/soramitsu/bootstrap/genesis/d3/D3TestGenesisFactory.kt
@@ -3,6 +3,7 @@ package jp.co.soramitsu.bootstrap.genesis.d3
 import com.google.protobuf.util.JsonFormat
 import jp.co.soramitsu.bootstrap.dto.AccountPrototype
 import jp.co.soramitsu.bootstrap.dto.AccountPublicInfo
+import jp.co.soramitsu.bootstrap.dto.AccountType
 import jp.co.soramitsu.bootstrap.dto.Peer
 import jp.co.soramitsu.bootstrap.exceptions.AccountException
 import jp.co.soramitsu.bootstrap.genesis.*
@@ -15,7 +16,7 @@ class D3TestGenesisFactory : GenesisInterface {
 
     private val zeroPubKey = "0000000000000000000000000000000000000000000000000000000000000000"
     override fun getAccountsForConfiguration(peersCount: Int): List<AccountPrototype> {
-        val activeAccounts = D3TestContext.d3neededAccounts.filter { !it.passive }
+        val activeAccounts = D3TestContext.d3neededAccounts.filter { it.type != AccountType.PASSIVE }
         activeAccounts
             .filter { it.peersDependentQuorum }
             .forEach { it.quorum = peersCount - peersCount / 3 }
@@ -66,28 +67,34 @@ class D3TestGenesisFactory : GenesisInterface {
         D3TestContext.d3neededAccounts.forEach { account ->
             val accountPubInfo = accountsMap[account.id]
             if (accountPubInfo != null) {
-                if (accountPubInfo.pubKeys.isNotEmpty()) {
-                    transactionBuilder.createAccount(
-                        account.name,
-                        account.domainId,
-                        getIrohaPublicKeyFromHex(accountPubInfo.pubKeys[0])
-                    )
-                    accountPubInfo.pubKeys.subList(1, accountPubInfo.pubKeys.size)
-                        .forEach { key ->
-                            transactionBuilder.addSignatory(
-                                account.id,
-                                getIrohaPublicKeyFromHex(key)
-                            )
-                        }
-                    if (account.peersDependentQuorum) {
-                        transactionBuilder.setAccountQuorum(accountPubInfo.id, accountPubInfo.quorum)
-                    } else if (account.quorum <= accountPubInfo.quorum) {
-                        transactionBuilder.setAccountQuorum(accountPubInfo.id, accountPubInfo.quorum)
+                if (account.type == AccountType.IGNORED) {
+                    if (accountPubInfo.pubKeys.size < accountPubInfo.quorum) {
+                        throw AccountException("Needed account keys are not received: ${account.id}")
                     }
                 } else {
-                    throw AccountException("Needed account keys are not received: ${account.id}")
+                    if (accountPubInfo.pubKeys.isNotEmpty()) {
+                        transactionBuilder.createAccount(
+                            account.name,
+                            account.domainId,
+                            getIrohaPublicKeyFromHex(accountPubInfo.pubKeys[0])
+                        )
+                        accountPubInfo.pubKeys.subList(1, accountPubInfo.pubKeys.size)
+                            .forEach { key ->
+                                transactionBuilder.addSignatory(
+                                    account.id,
+                                    getIrohaPublicKeyFromHex(key)
+                                )
+                            }
+                        if (account.peersDependentQuorum) {
+                            transactionBuilder.setAccountQuorum(accountPubInfo.id, accountPubInfo.quorum)
+                        } else if (account.quorum <= accountPubInfo.quorum) {
+                            transactionBuilder.setAccountQuorum(accountPubInfo.id, accountPubInfo.quorum)
+                        }
+                    } else {
+                        throw AccountException("Needed account keys are not received: ${account.id}")
+                    }
                 }
-            } else if (account.passive) {
+            } else if (account.type == AccountType.PASSIVE) {
                 transactionBuilder.createAccount(
                     account.name,
                     account.domainId,
@@ -105,9 +112,9 @@ class D3TestGenesisFactory : GenesisInterface {
     private fun checkAccountsGiven(accountsMap: HashMap<String, AccountPublicInfo>): List<String> {
         val errors = ArrayList<String>()
         D3TestContext.d3neededAccounts.forEach {
-            if (!accountsMap.containsKey(it.id) && !it.passive) {
+            if (!accountsMap.containsKey(it.id) && it.type != AccountType.PASSIVE) {
                 errors.add("Needed account keys are not received: ${it.id}")
-            } else if (!it.passive) {
+            } else if (it.type != AccountType.PASSIVE) {
                 val pubKeysCount = accountsMap[it.id]?.pubKeys?.size ?: 0
                 if (it.quorum > pubKeysCount || (accountsMap[it.id]?.quorum ?: 1 > pubKeysCount)) {
                     errors.add("Default or received quorum exceeds number of keys for account ${it.id}. Received(${accountsMap[it.id]?.quorum}) quorum should not be less than default(${it.quorum}) for this account")

--- a/bootstrap/src/test/kotlin/jp/co/soramitsu/bootstrap/IrohaTest.kt
+++ b/bootstrap/src/test/kotlin/jp/co/soramitsu/bootstrap/IrohaTest.kt
@@ -198,9 +198,7 @@ class IrohaTest {
                         "{\\\"appendRole\\\":{\\\"accountId\\\":\\\"" + account.id + "\\\",\\\"roleName\\\":\\\"" + role + "\\\"}}"
 
                     log.info("TestValue: $testValue")
-                    assertTrue(
-                        respBody.contains(testValue)
-                    )
+                    assertTrue(respBody.contains(testValue))
                 }
             }
         }
@@ -211,11 +209,7 @@ class IrohaTest {
         )
 
         jsonRolesContainsChecks.forEach {
-            assertTrue(
-                respBody.contains(
-                    "{\\\"createRole\\\":{\\\"roleName\\\":\\\"$it"
-                )
-            )
+            assertTrue(respBody.contains("{\\\"createRole\\\":{\\\"roleName\\\":\\\"$it"))
         }
 
         val genesisResponse =

--- a/bootstrap/src/test/kotlin/jp/co/soramitsu/bootstrap/IrohaTest.kt
+++ b/bootstrap/src/test/kotlin/jp/co/soramitsu/bootstrap/IrohaTest.kt
@@ -9,7 +9,6 @@ import jp.co.soramitsu.bootstrap.genesis.d3.D3TestContext
 import jp.co.soramitsu.bootstrap.genesis.d3.D3TestGenesisFactory
 import jp.co.soramitsu.crypto.ed25519.Ed25519Sha3
 import mu.KLogging
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.springframework.beans.factory.annotation.Autowired
@@ -25,6 +24,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.util.stream.Collectors.toList
 import javax.xml.bind.DatatypeConverter
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -42,6 +42,8 @@ class IrohaTest {
     val d3Genesis = D3TestGenesisFactory()
 
     private val mapper = ObjectMapper()
+
+    private val nonexistentAccounts = setOf("registration_service_primary@notary")
 
     @Test
     @Throws(Exception::class)
@@ -77,9 +79,9 @@ class IrohaTest {
             .andReturn()
         val respBody = mapper.readValue(result.response.contentAsString, NeededAccountsResponse().javaClass)
         val activeAccounts = ArrayList<AccountPrototype>()
-        d3Genesis.getAccountsForConfiguration(5).forEach { if (!it.passive) activeAccounts.add(it) }
+        d3Genesis.getAccountsForConfiguration(5).forEach { if (it.type != AccountType.PASSIVE) activeAccounts.add(it) }
         assertEquals(activeAccounts.size, respBody.accounts.size)
-        val dependentAccounts = respBody.accounts.stream().filter { it.peersDependentQuorum == true }.collect(toList())
+        val dependentAccounts = respBody.accounts.stream().filter { it.peersDependentQuorum }.collect(toList())
         dependentAccounts.forEach { assertEquals(4, it.quorum) }
     }
 
@@ -100,7 +102,7 @@ class IrohaTest {
             .andExpect(status().isOk)
             .andReturn()
         val respBody = mapper.readValue(result.response.contentAsString, NeededAccountsResponse().javaClass)
-        val dependentAccounts = respBody.accounts.stream().filter { it.peersDependentQuorum == true }.collect(toList())
+        val dependentAccounts = respBody.accounts.stream().filter { it.peersDependentQuorum }.collect(toList())
         dependentAccounts.forEach { assertEquals(1, it.quorum) }
     }
 
@@ -111,7 +113,7 @@ class IrohaTest {
             .andExpect(status().isOk)
             .andReturn()
         val respBody = mapper.readValue(result.response.contentAsString, NeededAccountsResponse().javaClass)
-        val dependentAccounts = respBody.accounts.stream().filter { it.peersDependentQuorum == true }.collect(toList())
+        val dependentAccounts = respBody.accounts.stream().filter { it.peersDependentQuorum }.collect(toList())
         dependentAccounts.forEach { assertEquals(2, it.quorum) }
     }
 
@@ -169,10 +171,12 @@ class IrohaTest {
         assertTrue(respBody.contains("firstTHost:12435"))
         assertTrue(respBody.contains("secondTHost:987654"))
 
-        //Check passive - keyless accounts added
+        //Check type - keyless accounts added
         assertTrue(respBody.contains("notaries"))
-        assertTrue(respBody.contains("gen_btc_pk_trigge"))
+        assertTrue(respBody.contains("gen_btc_pk_trigger"))
         assertTrue(respBody.contains("btc_change_addresses"))
+        //Check type - ignored accounts is not added
+        assertFalse(respBody.contains("registration_service_primary"))
 
         assertTrue(respBody.contains(peerKey1))
         assertTrue(respBody.contains(peerKey2))
@@ -182,29 +186,37 @@ class IrohaTest {
         val quorumCheck =
             "{\\\"accountId\\\":\\\"mst_btc_registration_service@notary\\\",\\\"quorum\\\":${peers.size - peers.size / 3}}"
         assertTrue(respBody.contains(quorumCheck))
-        accounts.forEach {
+        accounts.filter { !nonexistentAccounts.contains(it.id) }.forEach {
             val pubKey = it.pubKeys[0]
             assertTrue(
                 respBody.contains(pubKey),
                 "pubKey not exists in block when should for account ${it.accountName}@${it.domainId} pubKey:${it.pubKeys[0]}"
             )
-            D3TestContext.d3neededAccounts.forEach {account ->
-                account.roles.forEach {role ->
-                    val testValue = "{\\\"appendRole\\\":{\\\"accountId\\\":\\\"" + account.id + "\\\",\\\"roleName\\\":\\\"" + role + "\\\"}}"
+            D3TestContext.d3neededAccounts.forEach { account ->
+                account.roles.forEach { role ->
+                    val testValue =
+                        "{\\\"appendRole\\\":{\\\"accountId\\\":\\\"" + account.id + "\\\",\\\"roleName\\\":\\\"" + role + "\\\"}}"
 
                     log.info("TestValue: $testValue")
-                    assertTrue(respBody.contains(testValue)
+                    assertTrue(
+                        respBody.contains(testValue)
                     )
                 }
             }
         }
-        val jsonRolesContainsChecks = listOf("btc_fee_rate_setter",
+        val jsonRolesContainsChecks = listOf(
+            "btc_fee_rate_setter",
             "sora_client",
-            "notary_list_holder")
+            "notary_list_holder"
+        )
 
-        jsonRolesContainsChecks.forEach { assertTrue(respBody.contains(
-            "{\\\"createRole\\\":{\\\"roleName\\\":\\\"" + it
-        )) }
+        jsonRolesContainsChecks.forEach {
+            assertTrue(
+                respBody.contains(
+                    "{\\\"createRole\\\":{\\\"roleName\\\":\\\"$it"
+                )
+            )
+        }
 
         val genesisResponse =
             mapper.readValue(respBody, GenesisResponse::class.java)
@@ -238,7 +250,12 @@ class IrohaTest {
             createAccountDto("client_account", "notary"),
             createAccountDto("rmq", "notary", peersCount - peersCount / 3),
             createAccountDto("btc_consensus_collector", "notary"),
-            createAccountDto(ChangelogInterface.superuserAccount, ChangelogInterface.superuserDomain, peersCount - peersCount / 3)
+            createAccountDto("registration_service_primary", "notary"),
+            createAccountDto(
+                ChangelogInterface.superuserAccount,
+                ChangelogInterface.superuserDomain,
+                peersCount - peersCount / 3
+            )
         )
     }
 


### PR DESCRIPTION
<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * Jenkins builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->


### Description of the Change
Added nonexistent accounts key checking so that we can enforce key pair generation with proper naming but without actual account creation

### Usage Examples or Tests *[optional]*

