### PR TITLE
Mst changelog

### DIFF
--- a/bootstrap/src/integration-test/kotlin/jp/co/soramitsu/bootstrap/ChangelogIntegrationTest.kt
+++ b/bootstrap/src/integration-test/kotlin/jp/co/soramitsu/bootstrap/ChangelogIntegrationTest.kt
@@ -158,7 +158,7 @@ class ChangelogIntegrationTest {
                 ),
                 irohaConfig = IrohaConfig(IROHA_HOST, IROHA_PORT),
                 superuserKeys = listOf(
-                    ClientKeyPair(
+                    AccountKeyPair(
                         Utils.toHex(superuserKeyPair.public.encoded),
                         Utils.toHex(superuserKeyPair.private.encoded)
                     )
@@ -186,7 +186,7 @@ class ChangelogIntegrationTest {
                 ),
                 irohaConfig = IrohaConfig(IROHA_HOST, IROHA_PORT),
                 superuserKeys = listOf(
-                    ClientKeyPair(
+                    AccountKeyPair(
                         Utils.toHex(superuserKeyPair.public.encoded),
                         Utils.toHex(superuserKeyPair.private.encoded)
                     )

--- a/bootstrap/src/main/kotlin/jp/co/soramitsu/bootstrap/changelog/helper/ChangelogHelper.kt
+++ b/bootstrap/src/main/kotlin/jp/co/soramitsu/bootstrap/changelog/helper/ChangelogHelper.kt
@@ -1,0 +1,104 @@
+package jp.co.soramitsu.bootstrap.changelog.helper
+
+import jp.co.soramitsu.bootstrap.changelog.ChangelogInterface
+import jp.co.soramitsu.bootstrap.changelog.mapper.toChangelogAccount
+import jp.co.soramitsu.bootstrap.changelog.mapper.toChangelogPeer
+import jp.co.soramitsu.bootstrap.dto.AccountKeyPair
+import jp.co.soramitsu.bootstrap.dto.ChangelogRequestDetails
+import jp.co.soramitsu.iroha.java.IrohaAPI
+import jp.co.soramitsu.iroha.java.Query
+import jp.co.soramitsu.iroha.java.Transaction
+import jp.co.soramitsu.iroha.java.Utils
+import java.security.KeyPair
+import java.util.concurrent.atomic.AtomicLong
+
+private val queryCounter = AtomicLong()
+
+/**
+ * Signs changelog batch
+ * @param batch - changelog batch
+ * @param superuserKeys - keys that are used to sign given batch
+ */
+fun signChangelogBatch(
+    batch: List<Transaction>,
+    superuserKeys: List<AccountKeyPair>
+) {
+    superuserKeys.map { clientKeyPair ->
+        Utils.parseHexKeypair(
+            clientKeyPair.publicKey,
+            clientKeyPair.privateKey
+        )
+    }.forEach { keyPair ->
+        batch.forEach { tx ->
+            tx.sign(keyPair)
+        }
+    }
+}
+
+/**
+ * Creates changelog atomic batch
+ * @param changelogTx - transaction with changelog
+ * @param changelogHistoryTx - transaction with changelog history information
+ */
+fun createChangelogBatch(
+    changelogTx: Transaction,
+    changelogHistoryTx: Transaction
+): List<Transaction> {
+    return Utils.createTxUnsignedAtomicBatch(
+        listOf(changelogTx, changelogHistoryTx)
+    ).toList()
+}
+
+
+/**
+ * Creates changelog tx
+ * @param changelog - changelog script instance
+ * @param changelogRequestDetails - details of changelog
+ * @return changelog tx
+ */
+fun createChangelogTx(
+    changelog: ChangelogInterface,
+    changelogRequestDetails: ChangelogRequestDetails
+): Transaction {
+    return changelog.createChangelog(
+        changelogRequestDetails.accounts.map { toChangelogAccount(it) },
+        changelogRequestDetails.peers.map { toChangelogPeer(it) }
+    )
+}
+
+/**
+ * Adds superuser quorum to tx
+ * @param tx - transaction to modify
+ * @param quorum - quorum value that will be set
+ * @return modified tx
+ */
+fun addTxSuperuserQuorum(tx: Transaction, quorum: Int) = tx.makeMutable().setQuorum(quorum).build()
+
+/**
+ * Returns superuser account quorum
+ * @param irohaAPI - Iroha API that is used to get superuser account quorum
+ * @param superuserKeys - superuser keys that are used to query Iroha
+ * @throws Exception if Iroha level error occurred
+ * @return superuser quorum value
+ */
+fun getSuperuserQuorum(irohaAPI: IrohaAPI, superuserKeys: List<AccountKeyPair>): Int {
+    // The first key pair must be enough to create Iroha query
+    val firstKeyPair = superuserKeys.first()
+    val superuserKeyPair =
+        KeyPair(
+            Utils.parseHexPublicKey(firstKeyPair.publicKey), Utils.parseHexPrivateKey(firstKeyPair.privateKey)
+        )
+    val query = Query.builder(ChangelogInterface.superuserAccountId, queryCounter.getAndIncrement())
+        .getAccount(ChangelogInterface.superuserAccountId)
+        .buildSigned(superuserKeyPair)
+
+    val res = irohaAPI.query(query)
+    // Check errors
+    if (res.hasErrorResponse()) {
+        throw Exception(
+            "Cannot get ${ChangelogInterface.superuserAccountId} quorum. " +
+                    "Error code ${res.errorResponse.errorCode} reason ${res.errorResponse.reason}"
+        )
+    }
+    return res.accountResponse.account.quorum
+}

--- a/bootstrap/src/main/kotlin/jp/co/soramitsu/bootstrap/changelog/helper/ChangelogHelper.kt
+++ b/bootstrap/src/main/kotlin/jp/co/soramitsu/bootstrap/changelog/helper/ChangelogHelper.kt
@@ -12,7 +12,7 @@ import jp.co.soramitsu.iroha.java.Utils
 import java.security.KeyPair
 import java.util.concurrent.atomic.AtomicLong
 
-private val queryCounter = AtomicLong()
+private val queryCounter = AtomicLong(1)
 
 /**
  * Signs changelog batch

--- a/bootstrap/src/main/kotlin/jp/co/soramitsu/bootstrap/changelog/mapper/ChangelogMapper.kt
+++ b/bootstrap/src/main/kotlin/jp/co/soramitsu/bootstrap/changelog/mapper/ChangelogMapper.kt
@@ -1,0 +1,32 @@
+package jp.co.soramitsu.bootstrap.changelog.mapper
+
+import jp.co.soramitsu.bootstrap.changelog.ChangelogAccountPublicInfo
+import jp.co.soramitsu.bootstrap.changelog.ChangelogPeer
+import jp.co.soramitsu.bootstrap.dto.AccountPublicInfo
+import jp.co.soramitsu.bootstrap.dto.Peer
+
+/**
+ * Maps AccountPublicInfo to ChangelogAccountPublicInfo
+ * @param accountPublicInfo - account info to map
+ * @return ChangelogAccountPublicInfo
+ */
+fun toChangelogAccount(accountPublicInfo: AccountPublicInfo): ChangelogAccountPublicInfo {
+    val changelogAccount = ChangelogAccountPublicInfo()
+    changelogAccount.accountName = accountPublicInfo.accountName
+    changelogAccount.domainId = accountPublicInfo.domainId
+    changelogAccount.pubKeys = accountPublicInfo.pubKeys
+    changelogAccount.quorum = accountPublicInfo.quorum
+    return changelogAccount
+}
+
+/**
+ * Maps Peer to ChangelogPeer
+ * @param peer - peer to map
+ * @return ChangelogPeer
+ */
+fun toChangelogPeer(peer: Peer): ChangelogPeer {
+    val changelogPeer = ChangelogPeer()
+    changelogPeer.hostPort = peer.hostPort
+    changelogPeer.peerKey = peer.peerKey
+    return changelogPeer
+}

--- a/bootstrap/src/main/kotlin/jp/co/soramitsu/bootstrap/dto/ChangelogModel.kt
+++ b/bootstrap/src/main/kotlin/jp/co/soramitsu/bootstrap/dto/ChangelogModel.kt
@@ -5,7 +5,7 @@ data class ChangelogRequestDetails(
     val peers: List<Peer> = emptyList(),
     val meta: ProjectEnv = ProjectEnv(),
     val irohaConfig: IrohaConfig = IrohaConfig(),
-    val superuserKeys: List<ClientKeyPair> = emptyList()
+    val superuserKeys: List<AccountKeyPair> = emptyList()
 )
 
 data class ChangelogFileRequest(
@@ -18,4 +18,4 @@ data class ChangelogScriptRequest(
     val details: ChangelogRequestDetails = ChangelogRequestDetails()
 )
 
-data class ClientKeyPair(val publicKey: String = "", val privateKey: String = "")
+data class AccountKeyPair(val publicKey: String = "", val privateKey: String = "")


### PR DESCRIPTION
### Description of the Change
Now the changelog service works in MST fashion. Plus little refactor:
1) Helper functions were moved to the `helper` package
2) Mapping functions were moved to the `mapper` package
3) `ClientKeyPair` is renamed to `AccountKeyPair`