### PR TITLE
Forbid double Bitcoin registration

### DIFF
--- a/btc-registration/src/main/kotlin/com/d3/btc/registration/config/BtcRegistrationAppConfiguration.kt
+++ b/btc-registration/src/main/kotlin/com/d3/btc/registration/config/BtcRegistrationAppConfiguration.kt
@@ -43,6 +43,13 @@ class BtcRegistrationAppConfiguration {
     fun btcRegistrationConfig() = btcRegistrationConfig
 
     @Bean
+    fun btcRegisteredAddressesProvider() = BtcRegisteredAddressesProvider(
+        queryAPI(),
+        btcRegistrationCredential.accountId,
+        btcRegistrationConfig.notaryAccount
+    )
+
+    @Bean
     fun btcFreeAddressesProvider(): BtcFreeAddressesProvider {
         return BtcFreeAddressesProvider(
             btcRegistrationConfig.nodeId,
@@ -51,11 +58,7 @@ class BtcRegistrationAppConfiguration {
                 btcRegistrationConfig.mstRegistrationAccount,
                 btcRegistrationConfig.notaryAccount
             ),
-            BtcRegisteredAddressesProvider(
-                queryAPI(),
-                btcRegistrationCredential.accountId,
-                btcRegistrationConfig.notaryAccount
-            )
+            btcRegisteredAddressesProvider()
         )
     }
 

--- a/btc-registration/src/main/kotlin/com/d3/btc/registration/init/BtcRegistrationServiceInitialization.kt
+++ b/btc-registration/src/main/kotlin/com/d3/btc/registration/init/BtcRegistrationServiceInitialization.kt
@@ -1,12 +1,12 @@
 package com.d3.btc.registration.init
 
+import com.d3.btc.registration.config.BtcRegistrationConfig
+import com.d3.commons.registration.RegistrationServiceEndpoint
+import com.d3.commons.registration.RegistrationStrategy
 import com.github.kittinunf.result.Result
 import mu.KLogging
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import com.d3.commons.registration.RegistrationServiceEndpoint
-import com.d3.commons.registration.RegistrationStrategy
-import com.d3.btc.registration.config.BtcRegistrationConfig
 
 @Component
 class BtcRegistrationServiceInitialization(

--- a/btc/src/main/kotlin/com/d3/btc/provider/BtcRegisteredAddressesProvider.kt
+++ b/btc/src/main/kotlin/com/d3/btc/provider/BtcRegisteredAddressesProvider.kt
@@ -18,7 +18,7 @@ open class BtcRegisteredAddressesProvider(
     override fun monitor() = getRegisteredAddresses()
 
     /**
-     * Checks account if able to register in Bitcoin
+     * Checks if given account may be registered in Bitcoin
      * @param accountId - id of account to check
      * @return true if able to register
      */

--- a/btc/src/main/kotlin/com/d3/btc/provider/BtcRegisteredAddressesProvider.kt
+++ b/btc/src/main/kotlin/com/d3/btc/provider/BtcRegisteredAddressesProvider.kt
@@ -3,10 +3,11 @@ package com.d3.btc.provider
 import com.d3.btc.model.AddressInfo
 import com.d3.btc.model.BtcAddress
 import com.d3.btc.monitoring.Monitoring
+import com.d3.btc.provider.account.BTC_CURRENCY_NAME_KEY
+import com.d3.commons.sidechain.iroha.util.getAccountDetails
 import com.github.kittinunf.result.Result
 import com.github.kittinunf.result.map
 import jp.co.soramitsu.iroha.java.QueryAPI
-import com.d3.commons.sidechain.iroha.util.getAccountDetails
 
 //Class that provides all registered BTC addresses
 open class BtcRegisteredAddressesProvider(
@@ -15,6 +16,19 @@ open class BtcRegisteredAddressesProvider(
     private val notaryAccount: String
 ) : Monitoring() {
     override fun monitor() = getRegisteredAddresses()
+
+    /**
+     * Checks account if able to register in Bitcoin
+     * @param accountId - id of account to check
+     * @return true if able to register
+     */
+    fun ableToRegister(accountId: String): Result<Boolean, Exception> {
+        return getAccountDetails(queryAPI, accountId, registrationAccount)
+            .map { details ->
+                // Account hasn't been registered in Bitcoin yet
+                !details.containsKey(BTC_CURRENCY_NAME_KEY)
+            }
+    }
 
     /**
      * Get all registered btc addresses

--- a/eth-registration/src/main/kotlin/com/d3/eth/registration/EthRegistrationStrategyImpl.kt
+++ b/eth-registration/src/main/kotlin/com/d3/eth/registration/EthRegistrationStrategyImpl.kt
@@ -51,8 +51,9 @@ class EthRegistrationStrategyImpl(
             .flatMap { freeEthWallet ->
                 ethRelayProvider.getRelayByAccountId("$accountName@$domainId")
                     .flatMap { assignedRelays ->
+                        //TODO maybe check it before calling ethFreeRelayProvider.getRelay()?
                         // check that client hasn't been registered yet
-                        if (assignedRelays.isPresent())
+                        if (assignedRelays.isPresent)
                             throw IllegalArgumentException("Client $accountName@$domainId has already been registered with relay: ${assignedRelays.get()}")
 
                         // register to Ethereum RelayRegistry

--- a/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/BtcMultiWithdrawalIntegrationTest.kt
+++ b/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/BtcMultiWithdrawalIntegrationTest.kt
@@ -118,10 +118,8 @@ class BtcMultiWithdrawalIntegrationTest {
         val res = registrationServiceEnvironment.register(randomNameSrc, testClientSrcKeypair.public.toHexString())
         assertEquals(200, res.statusCode)
         generateAddress(BtcAddressType.FREE)
-        generateAddress(BtcAddressType.FREE)
         integrationHelper.registerBtcAddressNoPreGen(randomNameSrc, CLIENT_DOMAIN, testClientSrcKeypair)
-        val randomNameDest = String.getRandomString(9)
-        val btcAddressDest = integrationHelper.registerBtcAddressNoPreGen(randomNameDest, CLIENT_DOMAIN)
+        val btcAddressDest = integrationHelper.createBtcAddress(environment.transferWallet)
         integrationHelper.addIrohaAssetTo(testClientSrc, BTC_ASSET, amount)
         val initialSrcBalance = integrationHelper.getIrohaAccountBalance(testClientSrc, BTC_ASSET)
         integrationHelper.transferAssetIrohaFromClient(
@@ -157,12 +155,10 @@ class BtcMultiWithdrawalIntegrationTest {
         val res = registrationServiceEnvironment.register(randomNameSrc, testClientSrcKeypair.public.toHexString())
         assertEquals(200, res.statusCode)
         generateAddress(BtcAddressType.FREE)
-        generateAddress(BtcAddressType.FREE)
         val btcAddressSrc =
             integrationHelper.registerBtcAddressNoPreGen(randomNameSrc, CLIENT_DOMAIN, testClientSrcKeypair)
         integrationHelper.sendBtc(btcAddressSrc, 1, environment.btcWithdrawalConfig.bitcoin.confidenceLevel)
-        val randomNameDest = String.getRandomString(9)
-        val btcAddressDest = integrationHelper.registerBtcAddressNoPreGen(randomNameDest, CLIENT_DOMAIN)
+        val btcAddressDest = integrationHelper.createBtcAddress(environment.transferWallet)
         integrationHelper.addIrohaAssetTo(testClientSrc, BTC_ASSET, amount)
         integrationHelper.transferAssetIrohaFromClient(
             testClientSrc,

--- a/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/environment/BtcRegistrationTestEnvironment.kt
+++ b/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/environment/BtcRegistrationTestEnvironment.kt
@@ -44,6 +44,7 @@ class BtcRegistrationTestEnvironment(private val integrationHelper: BtcIntegrati
     val btcRegistrationServiceInitialization = BtcRegistrationServiceInitialization(
         btcRegistrationConfig,
         BtcRegistrationStrategyImpl(
+            btcRegisteredAddressesProvider(),
             btcFreeAddressesProvider,
             irohaBtcAccountCreator()
         )

--- a/notary-btc-integration-test/src/main/kotlin/integration/helper/BtcIntegrationHelperUtil.kt
+++ b/notary-btc-integration-test/src/main/kotlin/integration/helper/BtcIntegrationHelperUtil.kt
@@ -58,6 +58,12 @@ class BtcIntegrationHelperUtil(peers: Int = 1) : IrohaIntegrationHelperUtil(peer
         )
     }
 
+    private val btcRegisteredAddressesProvider = BtcRegisteredAddressesProvider(
+        queryAPI,
+        accountHelper.registrationAccount.accountId,
+        accountHelper.notaryAccount.accountId
+    )
+
     private val btcRegistrationStrategy by lazy {
         val btcAddressesProvider =
             BtcAddressesProvider(
@@ -76,6 +82,7 @@ class BtcIntegrationHelperUtil(peers: Int = 1) : IrohaIntegrationHelperUtil(peer
             accountHelper.notaryAccount.accountId
         )
         BtcRegistrationStrategyImpl(
+            btcRegisteredAddressesProvider,
             BtcFreeAddressesProvider(
                 NODE_ID,
                 btcAddressesProvider,


### PR DESCRIPTION
### Description of the Change
Now we check if we are able to register D3 clients in Bitcoin network. Currently, it just checks if D3 client hasn't been registered previously. This behavior is guarded by the test.