### PR TITLE
Fixed RMQ config

### DIFF
--- a/configs/chain-adapter.properties
+++ b/configs/chain-adapter.properties
@@ -1,0 +1,12 @@
+chain-adapter.rmqHost=d3-rmq
+chain-adapter.rmqPort=5672
+chain-adapter.irohaExchange=iroha
+chain-adapter.irohaCredential.accountId=rmq@notary
+chain-adapter.irohaCredential.pubkeyPath=deploy/iroha/keys/rmq@notary.pub
+chain-adapter.irohaCredential.privkeyPath=deploy/iroha/keys/rmq@notary.priv
+chain-adapter.lastReadBlockFilePath=deploy/chain-adapter/last_read_block.txt
+# --------- Iroha ---------
+# Iroha peer hostname
+chain-adapter.iroha.hostname=d3-iroha
+# Iroha peer port
+chain-adapter.iroha.port=50051

--- a/configs/rmq.properties
+++ b/configs/rmq.properties
@@ -1,11 +1,3 @@
 rmq.host=d3-rmq
+rmq.port=5672
 rmq.irohaExchange=iroha
-rmq.irohaCredential.accountId=rmq@notary
-rmq.irohaCredential.pubkeyPath=deploy/iroha/keys/rmq@notary.pub
-rmq.irohaCredential.privkeyPath=deploy/iroha/keys/rmq@notary.priv
-rmq.lastReadBlockFilePath=deploy/chain-adapter/last_read_block.txt
-# --------- Iroha ---------
-# Iroha peer hostname
-rmq.iroha.hostname=d3-iroha
-# Iroha peer port
-rmq.iroha.port=50051

--- a/notary-commons/src/main/kotlin/com/d3/commons/config/Configs.kt
+++ b/notary-commons/src/main/kotlin/com/d3/commons/config/Configs.kt
@@ -39,10 +39,8 @@ private val logger = KLogging().logger
  */
 interface RMQConfig {
     val host: String
+    val port: Int
     val irohaExchange: String
-    val irohaCredential: IrohaCredentialConfig
-    val iroha: IrohaConfig
-    val lastReadBlockFilePath: String
 }
 
 /**

--- a/notary-commons/src/main/kotlin/com/d3/commons/sidechain/iroha/ReliableIrohaChainListener.kt
+++ b/notary-commons/src/main/kotlin/com/d3/commons/sidechain/iroha/ReliableIrohaChainListener.kt
@@ -71,6 +71,7 @@ class ReliableIrohaChainListener(
             }
         }
         factory.host = rmqConfig.host
+        factory.port = rmqConfig.port
         if (consumerExecutorService != null) {
             factory.newConnection(consumerExecutorService)
         } else {


### PR DESCRIPTION
### Description of the Change
Fixed RMQ configuration. The `chain-adapter` service uses `chain-adapter.properties`, while the `ReliableChainListener` uses the same` rmq.properties` file, but now it's thinner.