### PR TITLE
Container helper

### DIFF
--- a/notary-iroha-integration-test/build.gradle
+++ b/notary-iroha-integration-test/build.gradle
@@ -11,6 +11,13 @@ dependencies {
     // unit tests
     testCompile('org.junit.jupiter:junit-jupiter-api:5.2.0')
     testRuntime('org.junit.jupiter:junit-jupiter-engine:5.2.0')
+    compile group: 'org.testcontainers', name: 'testcontainers', version: '1.11.2'
+    //Iroha-java related
+    compile('com.github.hyperledger.iroha-java:testcontainers:4.0.0')
+    compile('org.slf4j:slf4j-api:1.7.25')
+    compile('org.slf4j:slf4j-simple:1.7.25')
+    // https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java-util
+    compile group: 'com.google.protobuf', name: 'protobuf-java-util', version: '3.7.1'
 }
 
 sourceSets {

--- a/notary-iroha-integration-test/build.gradle
+++ b/notary-iroha-integration-test/build.gradle
@@ -7,10 +7,8 @@ buildscript {
 dependencies {
     compile project(":notary-commons")
     compile project(":notary-registration")
-
-    // unit tests
-    testCompile('org.junit.jupiter:junit-jupiter-api:5.2.0')
-    testRuntime('org.junit.jupiter:junit-jupiter-engine:5.2.0')
+    // We need this dependency to test our containers. 
+    // 'iroha-java:testcontainers' has this dependency inside but it's slightly old
     compile group: 'org.testcontainers', name: 'testcontainers', version: '1.11.2'
     //Iroha-java related
     compile('com.github.hyperledger.iroha-java:testcontainers:4.0.0')
@@ -18,6 +16,10 @@ dependencies {
     compile('org.slf4j:slf4j-simple:1.7.25')
     // https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java-util
     compile group: 'com.google.protobuf', name: 'protobuf-java-util', version: '3.7.1'
+
+    // unit tests
+    testCompile('org.junit.jupiter:junit-jupiter-api:5.2.0')
+    testRuntime('org.junit.jupiter:junit-jupiter-engine:5.2.0') 
 }
 
 sourceSets {

--- a/notary-iroha-integration-test/src/main/kotlin/integration/helper/ContainerHelper.kt
+++ b/notary-iroha-integration-test/src/main/kotlin/integration/helper/ContainerHelper.kt
@@ -31,7 +31,7 @@ class ContainerHelper : Closeable {
             .withPeerConfig(getPeerConfig())
             .withLogger(null)!! // turn of nasty Iroha logs
 
-    val rmq =
+    val rmqContainer =
         KGenericContainer("rabbitmq:3-management").withExposedPorts(DEFAULT_RMQ_PORT)
 
     /**
@@ -82,8 +82,8 @@ class ContainerHelper : Closeable {
         ) {
             irohaContainer.stop()
         }
-        if (rmq.isRunning) {
-            rmq.close()
+        if (rmqContainer.isRunning) {
+            rmqContainer.close()
         }
     }
 }

--- a/notary-iroha-integration-test/src/main/kotlin/integration/helper/ContainerHelper.kt
+++ b/notary-iroha-integration-test/src/main/kotlin/integration/helper/ContainerHelper.kt
@@ -1,0 +1,97 @@
+package integration.helper
+
+import com.d3.commons.sidechain.iroha.util.ModelUtil
+import com.google.protobuf.util.JsonFormat
+import iroha.protocol.BlockOuterClass
+import jp.co.soramitsu.iroha.testcontainers.IrohaContainer
+import jp.co.soramitsu.iroha.testcontainers.PeerConfig
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.images.builder.ImageFromDockerfile
+import java.io.Closeable
+import java.io.File
+
+
+const val DEFAULT_RMQ_PORT = 5672
+
+/**
+ * Helper that is used to start Iroha, create containers, etc
+ */
+class ContainerHelper : Closeable {
+
+    val userDir = System.getProperty("user.dir")!!
+
+    private val peerKeyPair =
+        ModelUtil.loadKeypair(
+            "$userDir/deploy/iroha/keys/node0.pub",
+            "$userDir/deploy/iroha/keys/node0.priv"
+        ).get()
+
+    val irohaContainer =
+        IrohaContainer()
+            .withPeerConfig(getPeerConfig())
+            .withLogger(null)!! // turn of nasty Iroha logs
+
+    val rmq =
+        KGenericContainer("rabbitmq:3-management").withExposedPorts(DEFAULT_RMQ_PORT)
+
+    /**
+     * Creates service docker container based on [dockerFile]
+     * @param jarFile - path to jar file that will be used to run service
+     * @param dockerFile - path to docker file that will be used to create containers
+     * @return container
+     */
+    fun createContainer(jarFile: String, dockerFile: String): KGenericContainerImage {
+        return KGenericContainerImage(
+            ImageFromDockerfile()
+                .withFileFromFile(jarFile, File(jarFile))
+                .withFileFromFile("Dockerfile", File(dockerFile)).withBuildArg("JAR_FILE", jarFile)
+        ).withLogConsumer { outputFrame -> print(outputFrame.utf8String) }.withNetworkMode("host")
+    }
+
+    /**
+     * Returns Iroha peer config
+     */
+    private fun getPeerConfig(): PeerConfig {
+        val builder = BlockOuterClass.Block.newBuilder()
+        JsonFormat.parser().merge(File("$userDir/deploy/iroha/genesis.block").readText(), builder)
+        val config = PeerConfig.builder()
+            .genesisBlock(builder.build())
+            .build()
+        config.withPeerKeyPair(peerKeyPair)
+        return config
+    }
+
+    /**
+     * Checks if service is healthy
+     * @param serviceContainer - container of service to check
+     * @param healthCheckPort - port of health check service
+     * @return true if healthy
+     */
+    fun isServiceHealthy(serviceContainer: KGenericContainerImage) = serviceContainer.isRunning
+
+    /**
+     * Cheks if service is dead
+     * @param serviceContainer - container of service to check
+     * @return true if dead
+     */
+    fun isServiceDead(serviceContainer: KGenericContainerImage) = !serviceContainer.isRunning
+
+    override fun close() {
+        if (irohaContainer.irohaDockerContainer != null
+            && irohaContainer.irohaDockerContainer.isRunning()
+        ) {
+            irohaContainer.stop()
+        }
+        if (rmq.isRunning) {
+            rmq.close()
+        }
+    }
+}
+
+/**
+ * The GenericContainer class is not very friendly to Kotlin.
+ * So the following classes were created as a workaround.
+ */
+class KGenericContainerImage(image: ImageFromDockerfile) : GenericContainer<KGenericContainerImage>(image)
+
+class KGenericContainer(imageName: String) : GenericContainer<KGenericContainer>(imageName)


### PR DESCRIPTION
### Description of the Change
In order to follow the DRY concept, `ContainerHelper` was moved to the main repository. Feel free to use it.