### PR TITLE
Health check endpoint

### DIFF
--- a/notary-commons/src/main/kotlin/com/d3/commons/healthcheck/HealthcheckEndpoint.kt
+++ b/notary-commons/src/main/kotlin/com/d3/commons/healthcheck/HealthcheckEndpoint.kt
@@ -1,0 +1,36 @@
+package com.d3.commons.healthcheck
+
+import io.ktor.application.call
+import io.ktor.application.install
+import io.ktor.features.CORS
+import io.ktor.features.ContentNegotiation
+import io.ktor.gson.gson
+import io.ktor.response.respond
+import io.ktor.routing.get
+import io.ktor.routing.routing
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.netty.Netty
+
+class HealthCheckEndpoint(healthCheckPort: Int) {
+
+    /**
+     * Initiates ktor based health check server
+     */
+    init {
+        val server = embeddedServer(Netty, port = healthCheckPort) {
+            install(CORS)
+            {
+                anyHost()
+            }
+            install(ContentNegotiation) {
+                gson()
+            }
+            routing {
+                get("/actuator/health") {
+                    call.respond(mapOf("status" to "UP"))
+                }
+            }
+        }
+        server.start(wait = false)
+    }
+}


### PR DESCRIPTION
### Description of the Change
Simple health check endpoint. May be used in modules like dApp, exchanger, chain-adapter, etc.