### PR TITLE
Fixed withdrawal permissions

### DIFF
--- a/bootstrap/src/main/kotlin/jp/co/soramitsu/bootstrap/genesis/d3/D3TestContext.kt
+++ b/bootstrap/src/main/kotlin/jp/co/soramitsu/bootstrap/genesis/d3/D3TestContext.kt
@@ -235,7 +235,11 @@ object D3TestContext {
                 Primitive.RolePermission.can_get_blocks,
                 Primitive.RolePermission.can_read_assets,
                 Primitive.RolePermission.can_receive,
-                Primitive.RolePermission.can_get_all_txs
+                Primitive.RolePermission.can_get_all_txs,
+                Primitive.RolePermission.can_set_detail,
+                Primitive.RolePermission.can_set_quorum,
+                Primitive.RolePermission.can_add_signatory,
+                Primitive.RolePermission.can_subtract_asset_qty
             )
 
         )

--- a/deploy/iroha/genesis.block
+++ b/deploy/iroha/genesis.block
@@ -162,7 +162,11 @@
                     "can_get_blocks",
                     "can_read_assets",
                     "can_receive",
-                    "can_get_all_txs"
+                    "can_get_all_txs",
+                    "can_add_signatory",
+                    "can_set_quorum",
+                    "can_set_detail",
+                    "can_subtract_asset_qty"
                   ]
                 }
               },


### PR DESCRIPTION
### Description of the Change
Updated withdrawal permissions
1. `can_add_signatory` - for notary expansion
2. `can_set_quorum` - the same
3. `can_set_detail` - for Bitcoin withdrawal service
4. `can_subtract_asset_qty` - for burning