### PR TITLE
Dummy SMTP server endpoint

### DIFF
--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -15,6 +15,12 @@ services:
     networks:
       - d3-network
 
+  d3-notifications:
+    ports:
+      - 8452:8452
+    networks:
+      - d3-network
+
   d3-rmq:
     ports:
       - 8181:15672

--- a/notary-commons/src/main/kotlin/com/d3/commons/healthcheck/HealthcheckEndpoint.kt
+++ b/notary-commons/src/main/kotlin/com/d3/commons/healthcheck/HealthcheckEndpoint.kt
@@ -13,16 +13,21 @@ import io.ktor.gson.gson
 import io.ktor.response.respond
 import io.ktor.routing.get
 import io.ktor.routing.routing
+import io.ktor.server.engine.ApplicationEngine
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
+import java.io.Closeable
+import java.util.concurrent.TimeUnit
 
-class HealthCheckEndpoint(healthCheckPort: Int) {
+class HealthCheckEndpoint(healthCheckPort: Int) : Closeable {
+
+    private val server: ApplicationEngine
 
     /**
      * Initiates ktor based health check server
      */
     init {
-        val server = embeddedServer(Netty, port = healthCheckPort) {
+        server = embeddedServer(Netty, port = healthCheckPort) {
             install(CORS)
             {
                 anyHost()
@@ -38,4 +43,9 @@ class HealthCheckEndpoint(healthCheckPort: Int) {
         }
         server.start(wait = false)
     }
+
+    override fun close() {
+        server.stop(5, 5, TimeUnit.SECONDS)
+    }
+
 }

--- a/notifications-integration-test/build.gradle
+++ b/notifications-integration-test/build.gradle
@@ -10,8 +10,6 @@ dependencies {
     // unit tests
     testCompile('org.junit.jupiter:junit-jupiter-api:5.2.0')
     testRuntime('org.junit.jupiter:junit-jupiter-engine:5.2.0')
-    // https://mvnrepository.com/artifact/dumbster/dumbster
-    testCompile group: 'com.github.kirviq', name: 'dumbster', version: '1.7.1'
 }
 
 sourceSets {

--- a/notifications-integration-test/src/integration-test/kotlin/notifications/NotificationsIntegrationTest.kt
+++ b/notifications-integration-test/src/integration-test/kotlin/notifications/NotificationsIntegrationTest.kt
@@ -9,15 +9,18 @@ import com.d3.commons.service.WithdrawalFinalizationDetails
 import com.d3.commons.service.WithdrawalFinalizer
 import com.d3.commons.sidechain.iroha.FEE_ROLLBACK_DESCRIPTION
 import com.d3.commons.sidechain.iroha.ROLLBACK_DESCRIPTION
+import com.d3.commons.util.GsonInstance
 import com.d3.commons.util.irohaEscape
 import com.d3.commons.util.toHexString
 import com.d3.notifications.client.D3_CLIENT_EMAIL_KEY
 import com.d3.notifications.client.D3_CLIENT_ENABLE_NOTIFICATIONS
 import com.d3.notifications.client.D3_CLIENT_PUSH_SUBSCRIPTION
+import com.d3.notifications.rest.dto.DumbsterMessage
 import com.d3.notifications.service.*
 import com.github.kittinunf.result.failure
 import com.github.kittinunf.result.flatMap
 import com.github.kittinunf.result.map
+import com.google.gson.reflect.TypeToken
 import com.nhaarman.mockitokotlin2.*
 import integration.helper.IrohaIntegrationHelperUtil
 import integration.registration.RegistrationServiceTestEnvironment
@@ -44,6 +47,8 @@ private const val SUBSCRIPTION_JSON = "{" +
 //TODO add new test (transfer with fee)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class NotificationsIntegrationTest {
+
+    private val gson = GsonInstance.get()
 
     private val integrationHelper = IrohaIntegrationHelperUtil()
 
@@ -175,13 +180,13 @@ class NotificationsIntegrationTest {
             )
         }.map {
             Thread.sleep(TRANSFER_WAIT_TIME)
-            val receivedEmails = environment.dumbster.receivedEmails
+            val receivedEmails = getAllMails()
             assertEquals(1, receivedEmails.size)
             val lastEmail = receivedEmails.last()
-            assertEquals(D3_DEPOSIT_EMAIL_SUBJECT, lastEmail.getHeaderValue("Subject"))
-            assertEquals(SRC_USER_EMAIL, lastEmail.getHeaderValue("To"))
-            assertEquals(NOTIFICATION_EMAIL, lastEmail.getHeaderValue("From"))
-            assertTrue(lastEmail.body.contains("from $from"))
+            assertEquals(D3_DEPOSIT_EMAIL_SUBJECT, lastEmail.subject)
+            assertEquals(SRC_USER_EMAIL, lastEmail.to)
+            assertEquals(NOTIFICATION_EMAIL, lastEmail.from)
+            assertTrue(lastEmail.message.contains("from $from"))
             verify(environment.pushService).send(any())
             Unit
         }.failure { ex -> fail(ex) }
@@ -217,14 +222,14 @@ class NotificationsIntegrationTest {
             withdrawalFinalizer.finalize(withdrawalFinalizationDetails)
         }.map {
             Thread.sleep(TRANSFER_WAIT_TIME)
-            val receivedEmails = environment.dumbster.receivedEmails
+            val receivedEmails = getAllMails()
             assertEquals(1, receivedEmails.size)
             val lastEmail = receivedEmails.last()
-            assertEquals(D3_WITHDRAWAL_EMAIL_SUBJECT, lastEmail.getHeaderValue("Subject"))
-            assertEquals(SRC_USER_EMAIL, lastEmail.getHeaderValue("To"))
-            assertEquals(NOTIFICATION_EMAIL, lastEmail.getHeaderValue("From"))
-            assertTrue(lastEmail.body.contains("Fee is $fee $BTC_ASSET"))
-            assertTrue(lastEmail.body.contains("to $destAddress"))
+            assertEquals(D3_WITHDRAWAL_EMAIL_SUBJECT, lastEmail.subject)
+            assertEquals(SRC_USER_EMAIL, lastEmail.to)
+            assertEquals(NOTIFICATION_EMAIL, lastEmail.from)
+            assertTrue(lastEmail.message.contains("Fee is $fee $BTC_ASSET"))
+            assertTrue(lastEmail.message.contains("to $destAddress"))
             verify(environment.pushService).send(any())
             Unit
         }.failure { ex -> fail(ex) }
@@ -260,14 +265,14 @@ class NotificationsIntegrationTest {
             withdrawalFinalizer.finalize(withdrawalFinalizationDetails)
         }.map {
             Thread.sleep(TRANSFER_WAIT_TIME)
-            val receivedEmails = environment.dumbster.receivedEmails
+            val receivedEmails = getAllMails()
             assertEquals(1, receivedEmails.size)
             val lastEmail = receivedEmails.last()
-            assertEquals(D3_WITHDRAWAL_EMAIL_SUBJECT, lastEmail.getHeaderValue("Subject"))
-            assertEquals(SRC_USER_EMAIL, lastEmail.getHeaderValue("To"))
-            assertEquals(NOTIFICATION_EMAIL, lastEmail.getHeaderValue("From"))
-            assertFalse(lastEmail.body.contains("Fee is"))
-            assertTrue(lastEmail.body.contains("to $destAddress"))
+            assertEquals(D3_WITHDRAWAL_EMAIL_SUBJECT, lastEmail.subject)
+            assertEquals(SRC_USER_EMAIL, lastEmail.to)
+            assertEquals(NOTIFICATION_EMAIL, lastEmail.from)
+            assertFalse(lastEmail.message.contains("Fee is"))
+            assertTrue(lastEmail.message.contains("to $destAddress"))
             verify(environment.pushService).send(any())
             Unit
         }.failure { ex -> fail(ex) }
@@ -301,12 +306,12 @@ class NotificationsIntegrationTest {
             )
         }.map {
             Thread.sleep(TRANSFER_WAIT_TIME)
-            val receivedEmails = environment.dumbster.receivedEmails
+            val receivedEmails = getAllMails()
             assertEquals(1, receivedEmails.size)
             val lastEmail = receivedEmails.last()
-            assertEquals(D3_DEPOSIT_ROLLBACK_SUBJECT, lastEmail.getHeaderValue("Subject"))
-            assertEquals(SRC_USER_EMAIL, lastEmail.getHeaderValue("To"))
-            assertEquals(NOTIFICATION_EMAIL, lastEmail.getHeaderValue("From"))
+            assertEquals(D3_DEPOSIT_ROLLBACK_SUBJECT, lastEmail.subject)
+            assertEquals(SRC_USER_EMAIL, lastEmail.to)
+            assertEquals(NOTIFICATION_EMAIL, lastEmail.from)
             verify(environment.pushService).send(any())
             Unit
         }.failure { ex -> fail(ex) }
@@ -351,13 +356,13 @@ class NotificationsIntegrationTest {
             integrationHelper.irohaConsumer.send(tx).get()
         }.map {
             Thread.sleep(TRANSFER_WAIT_TIME)
-            val receivedEmails = environment.dumbster.receivedEmails
+            val receivedEmails = getAllMails()
             assertEquals(1, receivedEmails.size)
             val lastEmail = receivedEmails.last()
-            assertEquals(D3_DEPOSIT_ROLLBACK_SUBJECT, lastEmail.getHeaderValue("Subject"))
-            assertEquals(SRC_USER_EMAIL, lastEmail.getHeaderValue("To"))
-            assertEquals(NOTIFICATION_EMAIL, lastEmail.getHeaderValue("From"))
-            assertTrue(lastEmail.body.contains("Fee $rollbackFeeValue $BTC_ASSET is rolled back as well."))
+            assertEquals(D3_DEPOSIT_ROLLBACK_SUBJECT, lastEmail.subject)
+            assertEquals(SRC_USER_EMAIL, lastEmail.to)
+            assertEquals(NOTIFICATION_EMAIL, lastEmail.from)
+            assertTrue(lastEmail.message.contains("Fee $rollbackFeeValue $BTC_ASSET is rolled back as well."))
             verify(environment.pushService).send(any())
             Unit
         }.failure { ex -> fail(ex) }
@@ -396,17 +401,18 @@ class NotificationsIntegrationTest {
             )
         }.map {
             Thread.sleep(TRANSFER_WAIT_TIME)
-            assertEquals(2, environment.dumbster.receivedEmails.size)
-            assertTrue(environment.dumbster.receivedEmails.any { message -> message.getHeaderValue("To") == SRC_USER_EMAIL })
-            assertTrue(environment.dumbster.receivedEmails.any { message -> message.getHeaderValue("To") == DEST_USER_EMAIL })
-            environment.dumbster.receivedEmails.forEach { message ->
-                assertEquals(D3_DEPOSIT_TRANSFER_SUBJECT, message.getHeaderValue("Subject"))
-                assertEquals(NOTIFICATION_EMAIL, message.getHeaderValue("From"))
-                assertFalse(message.body.contains("Fee is"))
-                if (message.getHeaderValue("To") == SRC_USER_EMAIL) {
-                    assertTrue(message.body.contains("to ${environment.destClientId}"))
-                } else if (message.getHeaderValue("To") == DEST_USER_EMAIL) {
-                    assertTrue(message.body.contains("from ${environment.srcClientId}"))
+            val mails = getAllMails()
+            assertEquals(2, mails.size)
+            assertTrue(mails.any { message -> message.to == SRC_USER_EMAIL })
+            assertTrue(mails.any { message -> message.to == DEST_USER_EMAIL })
+            mails.forEach { message ->
+                assertEquals(D3_DEPOSIT_TRANSFER_SUBJECT, message.subject)
+                assertEquals(NOTIFICATION_EMAIL, message.from)
+                assertFalse(message.message.contains("Fee is"))
+                if (message.to == SRC_USER_EMAIL) {
+                    assertTrue(message.message.contains("to ${environment.destClientId}"))
+                } else if (message.to == DEST_USER_EMAIL) {
+                    assertTrue(message.message.contains("from ${environment.srcClientId}"))
                 }
             }
             verify(environment.pushService, times(2)).send(any())
@@ -446,5 +452,18 @@ class NotificationsIntegrationTest {
             verify(environment.pushService, never()).send(any())
             Unit
         }.failure { ex -> fail(ex) }
+    }
+
+    /**
+     * Returns all the mails from the dumbster SMTP server using HTTP endpoint
+     * @return all mails
+     */
+    private fun getAllMails(): List<DumbsterMessage> {
+        val res = khttp.get("http://127.0.0.1:${environment.notificationsConfig.webPort}/dumbster/mail/all")
+        if (res.statusCode != 200) {
+            throw Exception("Cannot get emails from the dumbster endpoint. HTTP status code ${res.statusCode}")
+        }
+        val listType = object : TypeToken<List<DumbsterMessage>>() {}.type
+        return gson.fromJson(res.text, listType)
     }
 }

--- a/notifications-integration-test/src/integration-test/kotlin/notifications/environment/NotificationsIntegrationTestEnvironment.kt
+++ b/notifications-integration-test/src/integration-test/kotlin/notifications/environment/NotificationsIntegrationTestEnvironment.kt
@@ -16,6 +16,7 @@ import com.d3.notifications.init.NotificationInitialization
 import com.d3.notifications.provider.D3ClientProvider
 import com.d3.notifications.push.PushServiceFactory
 import com.d3.notifications.push.WebPushAPIServiceImpl
+import com.d3.notifications.rest.DumbsterEndpoint
 import com.d3.notifications.service.EmailNotificationService
 import com.d3.notifications.service.PushNotificationService
 import com.d3.notifications.smtp.SMTPServiceImpl
@@ -45,6 +46,8 @@ class NotificationsIntegrationTestEnvironment(private val integrationHelper: Iro
     val notificationsConfig = notificationsConfigHelper.createNotificationsConfig()
 
     val dumbster = SimpleSmtpServer.start(notificationsConfig.smtp.port)!!
+
+    val dumbsterEndpoint = DumbsterEndpoint(dumbster, notificationsConfig)
 
     private val irohaAPI =
         IrohaAPI(notificationsConfig.iroha.hostname, notificationsConfig.iroha.port)
@@ -113,5 +116,6 @@ class NotificationsIntegrationTestEnvironment(private val integrationHelper: Iro
         integrationHelper.close()
         irohaAPI.close()
         dumbster.close()
+        dumbsterEndpoint.close()
     }
 }

--- a/notifications-integration-test/src/main/kotlin/integration/helper/NotificationsConfigHelper.kt
+++ b/notifications-integration-test/src/main/kotlin/integration/helper/NotificationsConfigHelper.kt
@@ -20,6 +20,7 @@ class NotificationsConfigHelper(private val accountHelper: IrohaAccountHelper) :
             NotificationsConfig::class.java, "notifications.properties"
         )
         return object : NotificationsConfig {
+            override val webPort=notificationsConfig.webPort
             override val withdrawalBillingAccount = notificationsConfig.withdrawalBillingAccount
             override val transferBillingAccount = notificationsConfig.transferBillingAccount
             override val iroha = createIrohaConfig()

--- a/notifications/build.gradle
+++ b/notifications/build.gradle
@@ -1,4 +1,5 @@
 buildscript {
+    ext.ktor_version = '1.0.0'
     repositories {
         mavenCentral()
         jcenter()
@@ -48,6 +49,12 @@ dependencies {
     // https://mvnrepository.com/artifact/org.springframework/spring-context
     compile group: 'org.springframework', name: 'spring-context', version: '5.1.4.RELEASE'
 
+    // https://mvnrepository.com/artifact/dumbster/dumbster
+    compile group: 'com.github.kirviq', name: 'dumbster', version: '1.7.1'
+
+    // Ktor
+    compile "io.ktor:ktor-server-core:$ktor_version"
+    compile "io.ktor:ktor-server-netty:$ktor_version"
 }
 
 task runNotifications(type: JavaExec) {

--- a/notifications/src/main/kotlin/com/d3/notifications/config/NotificationAppConfiguration.kt
+++ b/notifications/src/main/kotlin/com/d3/notifications/config/NotificationAppConfiguration.kt
@@ -12,6 +12,7 @@ import com.d3.commons.sidechain.iroha.util.impl.IrohaQueryHelperImpl
 import com.d3.notifications.provider.D3ClientProvider
 import com.d3.notifications.push.PushServiceFactory
 import com.d3.notifications.smtp.SMTPServiceImpl
+import com.dumbster.smtp.SimpleSmtpServer
 import io.grpc.ManagedChannelBuilder
 import jp.co.soramitsu.iroha.java.IrohaAPI
 import jp.co.soramitsu.iroha.java.Utils
@@ -78,4 +79,8 @@ class NotificationAppConfiguration {
 
     @Bean
     fun notificationsConfig() = notificationsConfig
+
+    @Bean
+    fun dumbster() = SimpleSmtpServer.start(notificationsConfig.smtp.port)!!
+
 }

--- a/notifications/src/main/kotlin/com/d3/notifications/config/NotificationsConfig.kt
+++ b/notifications/src/main/kotlin/com/d3/notifications/config/NotificationsConfig.kt
@@ -24,6 +24,8 @@ interface NotificationsConfig {
     val transferBillingAccount: String
     // Billing account for withdrawals
     val withdrawalBillingAccount: String
+    // HTTP port for web-services
+    val webPort: Int
 }
 
 /**

--- a/notifications/src/main/kotlin/com/d3/notifications/rest/DumbsterEndpoint.kt
+++ b/notifications/src/main/kotlin/com/d3/notifications/rest/DumbsterEndpoint.kt
@@ -1,0 +1,71 @@
+package com.d3.notifications.rest
+
+import com.d3.notifications.config.NotificationsConfig
+import com.d3.notifications.rest.dto.TO_HEADER
+import com.d3.notifications.rest.dto.mapDumbsterMessage
+import com.dumbster.smtp.SimpleSmtpServer
+import io.ktor.application.call
+import io.ktor.application.install
+import io.ktor.features.CORS
+import io.ktor.features.ContentNegotiation
+import io.ktor.gson.gson
+import io.ktor.response.respond
+import io.ktor.routing.get
+import io.ktor.routing.routing
+import io.ktor.server.engine.ApplicationEngine
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.netty.Netty
+import org.springframework.stereotype.Component
+import java.io.Closeable
+import java.util.concurrent.TimeUnit
+
+
+/**
+ * HTTP endpoint for dummy 'dumbster' SMTP server. Good for testing.
+ */
+@Component
+class DumbsterEndpoint(
+    private val dumbster: SimpleSmtpServer,
+    notificationsConfig: NotificationsConfig
+) : Closeable {
+
+    private val server: ApplicationEngine
+
+    /**
+     * Initiates ktor based HTTP server
+     */
+    init {
+        server = embeddedServer(Netty, port = notificationsConfig.webPort) {
+            install(CORS)
+            {
+                anyHost()
+            }
+            install(ContentNegotiation) {
+                gson()
+            }
+            routing {
+                /**
+                 * Returns all the messages in the dumbster inbox
+                 */
+                get("/dumbster/mail/all") {
+                    val to = call.parameters["to"]
+                    val mails = if (to == null) {
+                        // Return all messages if 'to' header is not specified
+                        dumbster.receivedEmails.map { mapDumbsterMessage(it) }
+                    } else {
+                        // Return all messages with specified recipient
+                        dumbster.receivedEmails
+                            .filter { it.getHeaderValue(TO_HEADER) == to }
+                            .map { mapDumbsterMessage(it) }
+                    }
+                    call.respond(mails)
+                }
+            }
+        }
+        server.start(wait = false)
+    }
+
+    override fun close() {
+        server.stop(5, 5, TimeUnit.SECONDS)
+    }
+}

--- a/notifications/src/main/kotlin/com/d3/notifications/rest/dto/DTO.kt
+++ b/notifications/src/main/kotlin/com/d3/notifications/rest/dto/DTO.kt
@@ -1,0 +1,29 @@
+package com.d3.notifications.rest.dto
+
+import com.dumbster.smtp.SmtpMessage
+
+const val TO_HEADER = "To"
+const val FROM_HEADER = "From"
+const val SUBJECT_HEADER = "Subject"
+
+/**
+ * Data class that represents message from the dumbster SMTP server
+ */
+data class DumbsterMessage(
+    val from: String,
+    val to: String,
+    val subject: String,
+    val message: String
+)
+
+/**
+ * Maps [SmtpMessage] to [DumbsterMessage]
+ * @param mail - message to map
+ * @return mapped [DumbsterMessage]
+ */
+fun mapDumbsterMessage(mail: SmtpMessage) = DumbsterMessage(
+    from = mail.getHeaderValue(FROM_HEADER),
+    to = mail.getHeaderValue(TO_HEADER),
+    subject = mail.getHeaderValue(SUBJECT_HEADER),
+    message = mail.body
+)

--- a/notifications/src/main/resources/notifications.properties
+++ b/notifications/src/main/resources/notifications.properties
@@ -1,6 +1,7 @@
 # --------- Billing accounts-------
 notifications.transferBillingAccount=transfer_billing@d3
 notifications.withdrawalBillingAccount=withdrawal_billing@d3
+notifications.webPort=8452
 # --------- SMTP -------
 notifications.smtp.host=localhost
 notifications.smtp.port=2525


### PR DESCRIPTION
### Description of the Change
We need to test email notifications in D3. We cannot use a real SMTP server for testing purposes because it's not convenient for testing. It's possible to use mailtrap.io, but it has 500 messages per month limit. This is why I've just developed a self-made mail trap. 
Now, the notification service will create a dummy STMP server on start. All the messages sent to `localhost:2525` will be handled by the trap. HTTP endpoint (`/dumbster/mail/all`) for fetching emails is created as well.