### PR TITLE
Fixed SMTP message parsing

### DIFF
--- a/notifications/src/main/kotlin/com/d3/notifications/rest/dto/DTO.kt
+++ b/notifications/src/main/kotlin/com/d3/notifications/rest/dto/DTO.kt
@@ -25,5 +25,18 @@ fun mapDumbsterMessage(mail: SmtpMessage) = DumbsterMessage(
     from = mail.getHeaderValue(FROM_HEADER),
     to = mail.getHeaderValue(TO_HEADER),
     subject = mail.getHeaderValue(SUBJECT_HEADER),
-    message = mail.body
+    message = parseSMTPMessageBody(mail)
 )
+
+/**
+ * Takes text from SMTP message
+ * @param mail - SMTP message
+ * @return plain text with no SMTP-related headers
+ */
+private fun parseSMTPMessageBody(mail: SmtpMessage): String {
+    val message = mail.body
+    return message.substring(
+        message.indexOf('\n') + 1,
+        message.lastIndexOf("------")
+    )
+}


### PR DESCRIPTION
### Description of the Change
Fake SMTP server stores messages in a very inconvenient way. We need to parse every message to fetch text with no extra SMTP headers. 