### PR TITLE
Fix memory consumption

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -133,6 +133,7 @@ services:
       IROHA_PORT: 50051
       SPRING_DATASOURCE_USERNAME: test
       SPRING_DATASOURCE_PASSWORD: test
+      JAVA_OPTIONS: -Xmx512m
     networks:
       - d3-network
 
@@ -149,6 +150,7 @@ services:
       POSTGRES_DATABASE: postgres
       SPRING_DATASOURCE_USERNAME: test
       SPRING_DATASOURCE_PASSWORD: test
+      JAVA_OPTIONS: -Xmx512m
     networks:
       - d3-network
 


### PR DESCRIPTION
### Description of the Change
We must fix memory consumption in data-collector and report-service because they take to much of RAM at startup. There is no need to use this fix in production. This fix is dedicated to our testers.

PS.
**Xmx** option - sets the maximum Java heap size