### PR TITLE
Changed query API

### DIFF
--- a/notary-commons/src/main/kotlin/com/d3/commons/sidechain/iroha/util/IrohaPaginationHelper.kt
+++ b/notary-commons/src/main/kotlin/com/d3/commons/sidechain/iroha/util/IrohaPaginationHelper.kt
@@ -123,10 +123,10 @@ class IrohaPaginationHelper(private val queryAPI: QueryAPI, private val pageSize
                     .getOrDefault(writerAccountId, emptyMap())
                     .entries.firstOrNull { entry -> firstPredicate(entry.key, entry.value) }
             if (firstDetails != null) {
-                return@of Optional.of(Pair(firstDetails.key, firstDetails.value))
+                return@of Optional.of<Map.Entry<String,String>>(AbstractMap.SimpleEntry(firstDetails.key, firstDetails.value))
             }
         } while (response.hasNextRecordId())
-        return@of Optional.empty<Pair<String, String>>()
+        return@of Optional.empty<Map.Entry<String, String>>()
     }
 
     /**

--- a/notary-commons/src/main/kotlin/com/d3/commons/sidechain/iroha/util/IrohaQueryHelper.kt
+++ b/notary-commons/src/main/kotlin/com/d3/commons/sidechain/iroha/util/IrohaQueryHelper.kt
@@ -55,7 +55,7 @@ interface IrohaQueryHelper {
         storageAccountId: String,
         writerAccountId: String,
         firstPredicate: (key: String, value: String) -> Boolean
-    ): Result<Optional<Pair<String, String>>, Exception>
+    ): Result<Optional<Map.Entry<String, String>>, Exception>
 
     /**
      * Retrieves account details by setter filtered by predicate from Iroha

--- a/notary-commons/src/main/kotlin/com/d3/commons/sidechain/iroha/util/impl/IrohaQueryHelperImpl.kt
+++ b/notary-commons/src/main/kotlin/com/d3/commons/sidechain/iroha/util/impl/IrohaQueryHelperImpl.kt
@@ -79,7 +79,7 @@ open class IrohaQueryHelperImpl(
         storageAccountId: String,
         writerAccountId: String,
         firstPredicate: (key: String, value: String) -> Boolean
-    ): Result<Optional<Pair<String, String>>, Exception> =
+    ): Result<Optional<Map.Entry<String, String>>, Exception> =
         irohaPaginationHelper.getPaginatedAccountDetailsFirst(storageAccountId, writerAccountId, firstPredicate)
 
     /** {@inheritDoc} */

--- a/notary-commons/src/test/kotlin/com/d3/commons/sidechain/iroha/util/impl/IrohaQueryHelperImplTest.kt
+++ b/notary-commons/src/test/kotlin/com/d3/commons/sidechain/iroha/util/impl/IrohaQueryHelperImplTest.kt
@@ -309,7 +309,7 @@ class IrohaQueryHelperImplTest {
                 accountId,
                 accountId,
                 predicate
-            ).get().get().first
+            ).get().get().key
         )
     }
 


### PR DESCRIPTION
### Description of the Change
`Pair` is not convenient to use. It's very easy to mess with `first` and `second`. It's much easier to use `key` and `value` instead.