### PR TITLE
Ignoring notifications in Sora

### DIFF
--- a/notary-iroha-integration-test/src/main/kotlin/integration/helper/IrohaAccountHelper.kt
+++ b/notary-iroha-integration-test/src/main/kotlin/integration/helper/IrohaAccountHelper.kt
@@ -139,6 +139,10 @@ open class IrohaAccountHelper(private val irohaAPI: IrohaAPI, private val peers:
         createTesterAccount("eth_reg", listOf("registration_service"))
     }
 
+    val ethWithdrawalAccount by lazy {
+        createTesterAccount("eth_withdrawal", listOf("withdrawal"))
+    }
+
     /** Account that registers Bitcoin addresses */
     val btcRegistrationAccount by lazy {
         createTesterAccount("btc_reg", listOf("registration_service"))

--- a/notifications-integration-test/src/integration-test/kotlin/notifications/NotificationsIntegrationTest.kt
+++ b/notifications-integration-test/src/integration-test/kotlin/notifications/NotificationsIntegrationTest.kt
@@ -39,7 +39,6 @@ import org.junit.jupiter.api.Assertions.*
 import java.lang.reflect.Type
 import java.math.BigDecimal
 
-const val BTC_ASSET = "btc#bitcoin"
 private const val WAIT_TIME = 5_000L
 private const val SRC_USER_EMAIL = "src.user@d3.com"
 private const val DEST_USER_EMAIL = "dest.user@d3.com"
@@ -114,21 +113,21 @@ class NotificationsIntegrationTest {
         // Enriching notary account
         integrationHelper.addIrohaAssetTo(
             integrationHelper.accountHelper.notaryAccount.accountId,
-            BTC_ASSET,
+            ETH_ASSET_ID,
             amount
         )
 
         // Enriching withdrawal account
         integrationHelper.addIrohaAssetTo(
-            integrationHelper.accountHelper.btcWithdrawalAccount.accountId,
-            BTC_ASSET,
+            integrationHelper.accountHelper.ethWithdrawalAccount.accountId,
+            ETH_ASSET_ID,
             amount
         )
 
         // Enriching src account
         integrationHelper.addIrohaAssetTo(
             environment.srcClientId,
-            BTC_ASSET,
+            ETH_ASSET_ID,
             amount
         )
 
@@ -176,7 +175,7 @@ class NotificationsIntegrationTest {
                 notaryAccount.keyPair,
                 notaryAccount.accountId,
                 environment.srcClientId,
-                BTC_ASSET,
+                ETH_ASSET_ID,
                 from,
                 depositValue.toPlainString(),
                 quorum = 1
@@ -194,7 +193,7 @@ class NotificationsIntegrationTest {
             val soraEvent = getLastSoraEvent("deposit") as SoraDepositEvent
             assertEquals(environment.srcClientId, soraEvent.accountIdToNotify)
             assertEquals(depositValue, soraEvent.amount)
-            assertEquals(BTC_ASSET, soraEvent.assetName)
+            assertEquals(ETH_ASSET_ID, soraEvent.assetName)
             Unit
         }.failure { ex -> fail(ex) }
     }
@@ -273,10 +272,6 @@ class NotificationsIntegrationTest {
             verify(environment.pushService).send(any())
             assertTrue(lastEmail.message.contains(btcAddress))
             assertTrue(lastEmail.message.contains(RegistrationEventSubsystem.BTC.toString()))
-            val soraEvent = getLastSoraEvent("registration") as SoraRegistrationEvent
-            assertEquals(RegistrationEventSubsystem.BTC.name, soraEvent.subsystem)
-            assertEquals(environment.srcClientConsumer.creator, soraEvent.accountIdToNotify)
-            assertEquals(btcAddress, soraEvent.address)
             Unit
         }.failure { ex -> fail(ex) }
     }
@@ -304,9 +299,9 @@ class NotificationsIntegrationTest {
             )
             val withdrawalFinalizationDetails = WithdrawalFinalizationDetails(
                 withdrawalValue,
-                BTC_ASSET,
+                ETH_ASSET_ID,
                 fee,
-                BTC_ASSET,
+                ETH_ASSET_ID,
                 environment.srcClientId,
                 System.currentTimeMillis(),
                 destAddress
@@ -320,16 +315,16 @@ class NotificationsIntegrationTest {
             assertEquals(D3_WITHDRAWAL_EMAIL_SUBJECT, lastEmail.subject)
             assertEquals(SRC_USER_EMAIL, lastEmail.to)
             assertEquals(NOTIFICATION_EMAIL, lastEmail.from)
-            assertTrue(lastEmail.message.contains("Fee is $fee $BTC_ASSET"))
+            assertTrue(lastEmail.message.contains("Fee is $fee $ETH_ASSET_ID"))
             assertTrue(lastEmail.message.contains("to $destAddress"))
             verify(environment.pushService).send(any())
             val soraEvent = getLastSoraEvent("withdrawal") as SoraWithdrawalEvent
             assertEquals(environment.srcClientId, soraEvent.accountIdToNotify)
             assertEquals(destAddress, soraEvent.to)
             assertEquals(withdrawalValue, soraEvent.amount)
-            assertEquals(BTC_ASSET, soraEvent.assetName)
+            assertEquals(ETH_ASSET_ID, soraEvent.assetName)
             assertEquals(fee, soraEvent.fee)
-            assertEquals(BTC_ASSET, soraEvent.feeAssetName)
+            assertEquals(ETH_ASSET_ID, soraEvent.feeAssetName)
             Unit
         }.failure { ex -> fail(ex) }
     }
@@ -357,9 +352,9 @@ class NotificationsIntegrationTest {
             )
             val withdrawalFinalizationDetails = WithdrawalFinalizationDetails(
                 withdrawalValue,
-                BTC_ASSET,
+                ETH_ASSET_ID,
                 fee,
-                BTC_ASSET,
+                ETH_ASSET_ID,
                 environment.srcClientId,
                 System.currentTimeMillis(),
                 destAddress
@@ -380,7 +375,7 @@ class NotificationsIntegrationTest {
             assertEquals(environment.srcClientId, soraEvent.accountIdToNotify)
             assertEquals(destAddress, soraEvent.to)
             assertEquals(withdrawalValue, soraEvent.amount)
-            assertEquals(BTC_ASSET, soraEvent.assetName)
+            assertEquals(ETH_ASSET_ID, soraEvent.assetName)
             assertNull(soraEvent.fee)
             assertNull(soraEvent.feeAssetName)
             Unit
@@ -408,7 +403,7 @@ class NotificationsIntegrationTest {
                 notaryAccount.keyPair,
                 notaryAccount.accountId,
                 environment.srcClientId,
-                BTC_ASSET,
+                ETH_ASSET_ID,
                 ROLLBACK_DESCRIPTION,
                 rollbackValue.toPlainString(),
                 quorum = 1
@@ -447,14 +442,14 @@ class NotificationsIntegrationTest {
                 .transferAsset(
                     notaryAccount.accountId,
                     environment.srcClientId,
-                    BTC_ASSET,
+                    ETH_ASSET_ID,
                     ROLLBACK_DESCRIPTION,
                     rollbackValue.toPlainString()
                 )
                 .transferAsset(
                     notaryAccount.accountId,
                     environment.srcClientId,
-                    BTC_ASSET,
+                    ETH_ASSET_ID,
                     FEE_ROLLBACK_DESCRIPTION,
                     rollbackFeeValue.toPlainString()
                 )
@@ -471,7 +466,7 @@ class NotificationsIntegrationTest {
             assertEquals(D3_ROLLBACK_SUBJECT, lastEmail.subject)
             assertEquals(SRC_USER_EMAIL, lastEmail.to)
             assertEquals(NOTIFICATION_EMAIL, lastEmail.from)
-            assertTrue(lastEmail.message.contains("Fee $rollbackFeeValue $BTC_ASSET is rolled back as well."))
+            assertTrue(lastEmail.message.contains("Fee $rollbackFeeValue $ETH_ASSET_ID is rolled back as well."))
             verify(environment.pushService).send(any())
             Unit
         }.failure { ex -> fail(ex) }
@@ -504,7 +499,7 @@ class NotificationsIntegrationTest {
                 environment.srcClientKeyPair,
                 environment.srcClientId,
                 environment.destClientId,
-                BTC_ASSET,
+                ETH_ASSET_ID,
                 "no description",
                 transferValue.toPlainString()
             )
@@ -550,7 +545,7 @@ class NotificationsIntegrationTest {
                 notaryAccount.keyPair,
                 notaryAccount.accountId,
                 environment.srcClientId,
-                BTC_ASSET,
+                ETH_ASSET_ID,
                 "no description",
                 depositValue.toPlainString(),
                 quorum = 1
@@ -591,8 +586,6 @@ class NotificationsIntegrationTest {
             "deposit" -> SoraDepositEvent::class.java
             "withdrawal" -> SoraWithdrawalEvent::class.java
             "registration" -> SoraRegistrationEvent::class.java
-            "transferSend" -> SoraTransferEventSend::class.java
-            "transferReceive" -> SoraTransferEventReceive::class.java
             else -> throw IllegalArgumentException("Event type $eventType is not supported")
         }
         val jsonArray = JSONArray(res.text)

--- a/notifications-integration-test/src/integration-test/kotlin/notifications/environment/NotificationsIntegrationTestEnvironment.kt
+++ b/notifications-integration-test/src/integration-test/kotlin/notifications/environment/NotificationsIntegrationTestEnvironment.kt
@@ -146,7 +146,7 @@ class NotificationsIntegrationTestEnvironment(private val integrationHelper: Iro
             eventsQueue
         )
 
-    val withdrawalIrohaConsumer = IrohaConsumerImpl(integrationHelper.accountHelper.btcWithdrawalAccount, irohaAPI)
+    val withdrawalIrohaConsumer = IrohaConsumerImpl(integrationHelper.accountHelper.ethWithdrawalAccount, irohaAPI)
 
     // Source account
     val srcClientName = String.getRandomString(9)

--- a/notifications/src/main/kotlin/com/d3/notifications/debug/DebugEndpoint.kt
+++ b/notifications/src/main/kotlin/com/d3/notifications/debug/DebugEndpoint.kt
@@ -3,8 +3,13 @@ package com.d3.notifications.debug
 import com.d3.notifications.config.NotificationsConfig
 import com.d3.notifications.debug.dto.TO_HEADER
 import com.d3.notifications.debug.dto.mapDumbsterMessage
-import com.d3.notifications.event.*
-import com.d3.notifications.service.*
+import com.d3.notifications.event.SoraDepositEvent
+import com.d3.notifications.event.SoraEvent
+import com.d3.notifications.event.SoraRegistrationEvent
+import com.d3.notifications.event.SoraWithdrawalEvent
+import com.d3.notifications.service.DEPOSIT_URI
+import com.d3.notifications.service.REGISTRATION_URI
+import com.d3.notifications.service.WITHDRAWAL_URI
 import com.dumbster.smtp.SimpleSmtpServer
 import io.ktor.application.call
 import io.ktor.application.install
@@ -36,8 +41,6 @@ class DebugEndpoint(
     private val soraDepositEvents = Collections.synchronizedList(ArrayList<SoraDepositEvent>())
     private val soraWithdrawalEvents = Collections.synchronizedList(ArrayList<SoraWithdrawalEvent>())
     private val soraRegistrationEvents = Collections.synchronizedList(ArrayList<SoraRegistrationEvent>())
-    private val soraTransferSendEvents = Collections.synchronizedList(ArrayList<SoraTransferEventSend>())
-    private val soraTransferReceiveEvents = Collections.synchronizedList(ArrayList<SoraTransferEventReceive>())
 
     /**
      * Initiates ktor based HTTP server
@@ -75,8 +78,6 @@ class DebugEndpoint(
                     val eventType = call.parameters["eventType"]
                     call.respond(
                         when (eventType) {
-                            "transferSend" -> soraTransferSendEvents
-                            "transferReceive" -> soraTransferReceiveEvents
                             "deposit" -> soraDepositEvents
                             "registration" -> soraRegistrationEvents
                             "withdrawal" -> soraWithdrawalEvents
@@ -92,16 +93,6 @@ class DebugEndpoint(
                 post("/sora/$WITHDRAWAL_URI") {
                     val withdrawalEvent = call.receive<SoraWithdrawalEvent>()
                     soraWithdrawalEvents.add(withdrawalEvent)
-                    call.respond("Ok")
-                }
-                post("/sora/$TRANSFER_RECEIVE_URI") {
-                    val transferEventReceive = call.receive<SoraTransferEventReceive>()
-                    soraTransferReceiveEvents.add(transferEventReceive)
-                    call.respond("Ok")
-                }
-                post("/sora/$TRANSFER_SEND_URI") {
-                    val transferEventSend = call.receive<SoraTransferEventSend>()
-                    soraTransferSendEvents.add(transferEventSend)
                     call.respond("Ok")
                 }
                 post("/sora/$REGISTRATION_URI") {

--- a/notifications/src/main/kotlin/com/d3/notifications/event/SoraEvents.kt
+++ b/notifications/src/main/kotlin/com/d3/notifications/event/SoraEvents.kt
@@ -16,50 +16,6 @@ import java.math.BigDecimal
  */
 interface SoraEvent
 
-data class SoraTransferEventReceive(
-    val accountIdToNotify: String,
-    val amount: BigDecimal,
-    val assetName: String,
-    val from: String,
-    val description: String?
-) : SoraEvent {
-    companion object {
-        fun map(transferNotifyEvent: TransferNotifyEvent): SoraTransferEventReceive {
-            return SoraTransferEventReceive(
-                transferNotifyEvent.accountIdToNotify,
-                transferNotifyEvent.amount,
-                transferNotifyEvent.assetName,
-                transferNotifyEvent.from!!,
-                transferNotifyEvent.description
-            )
-        }
-    }
-}
-
-data class SoraTransferEventSend(
-    val accountIdToNotify: String,
-    val amount: BigDecimal,
-    val assetName: String,
-    val to: String,
-    val description: String?,
-    val fee: BigDecimal?,
-    val feeAssetName: String?
-) : SoraEvent {
-    companion object {
-        fun map(transferNotifyEvent: TransferNotifyEvent): SoraTransferEventSend {
-            return SoraTransferEventSend(
-                transferNotifyEvent.accountIdToNotify,
-                transferNotifyEvent.amount,
-                transferNotifyEvent.assetName,
-                transferNotifyEvent.to!!,
-                transferNotifyEvent.description,
-                transferNotifyEvent.fee,
-                transferNotifyEvent.feeAssetName
-            )
-        }
-    }
-}
-
 data class SoraDepositEvent(
     val accountIdToNotify: String,
     val amount: BigDecimal,

--- a/notifications/src/main/kotlin/com/d3/notifications/service/SoraNotificationService.kt
+++ b/notifications/src/main/kotlin/com/d3/notifications/service/SoraNotificationService.kt
@@ -14,8 +14,7 @@ import org.json.JSONObject
 const val DEPOSIT_URI = "deposit"
 const val WITHDRAWAL_URI = "withdrawal"
 const val REGISTRATION_URI = "registration"
-const val TRANSFER_RECEIVE_URI = "transferReceive"
-const val TRANSFER_SEND_URI = "transferSend"
+const val ETH_ASSET_ID = "ether#ethereum"
 
 /**
  * Notification service used by Sora
@@ -23,6 +22,9 @@ const val TRANSFER_SEND_URI = "transferSend"
 class SoraNotificationService(private val soraConfig: SoraConfig) : NotificationService {
 
     override fun notifyDeposit(transferNotifyEvent: TransferNotifyEvent): Result<Unit, Exception> {
+        if (transferNotifyEvent.assetName != ETH_ASSET_ID) {
+            return Result.of { logger.warn("Sora notification service is not interested in ${transferNotifyEvent.assetName} deposits") }
+        }
         logger.info("Notify Sora deposit $transferNotifyEvent")
         return Result.of {
             postSoraEvent(
@@ -33,6 +35,9 @@ class SoraNotificationService(private val soraConfig: SoraConfig) : Notification
     }
 
     override fun notifyWithdrawal(transferNotifyEvent: TransferNotifyEvent): Result<Unit, Exception> {
+        if (transferNotifyEvent.assetName != ETH_ASSET_ID) {
+            return Result.of { logger.warn("Sora notification service is not interested in ${transferNotifyEvent.assetName} withdrawals") }
+        }
         logger.info("Notify Sora withdrawal $transferNotifyEvent")
         return Result.of {
             postSoraEvent(
@@ -45,31 +50,28 @@ class SoraNotificationService(private val soraConfig: SoraConfig) : Notification
     override fun notifySendToClient(transferNotifyEvent: TransferNotifyEvent): Result<Unit, Exception> {
         logger.info("Notify Sora transfer send $transferNotifyEvent")
         return Result.of {
-            postSoraEvent(
-                soraConfig.notificationServiceURL + "/" + TRANSFER_SEND_URI,
-                SoraTransferEventSend.map(transferNotifyEvent)
-            )
+            logger.warn("'Transfer send' notifications are not supported in Sora")
         }
     }
 
     override fun notifyReceiveFromClient(transferNotifyEvent: TransferNotifyEvent): Result<Unit, Exception> {
         logger.info("Notify Sora transfer receive $transferNotifyEvent")
         return Result.of {
-            postSoraEvent(
-                soraConfig.notificationServiceURL + "/" + TRANSFER_RECEIVE_URI,
-                SoraTransferEventReceive.map(transferNotifyEvent)
-            )
+            logger.warn("'Transfer receive' notifications are not supported in Sora")
         }
     }
 
     override fun notifyRollback(transferNotifyEvent: TransferNotifyEvent): Result<Unit, Exception> {
         logger.info("Notify Sora rollback $transferNotifyEvent")
         return Result.of {
-            logger.warn("Rollback is not supported in Sora")
+            logger.warn("Rollback notifications are not supported in Sora")
         }
     }
 
     override fun notifyRegistration(registrationNotifyEvent: RegistrationNotifyEvent): Result<Unit, Exception> {
+        if (registrationNotifyEvent.subsystem != RegistrationEventSubsystem.ETH) {
+            return Result.of { logger.warn("Sora notification service is not interested in ${registrationNotifyEvent.subsystem.name} registrations") }
+        }
         logger.info("Notify Sora registration $registrationNotifyEvent")
         return Result.of {
             postSoraEvent(


### PR DESCRIPTION
### Description of the Change
Sora is not interested in non-Ethereum events. So we have to get rid of them.
