### PR TITLE
Add gas in withdrawal notifications

### DIFF
--- a/notary-commons/src/main/kotlin/com/d3/commons/service/WithdrawalFinalizationDetails.kt
+++ b/notary-commons/src/main/kotlin/com/d3/commons/service/WithdrawalFinalizationDetails.kt
@@ -18,6 +18,7 @@ import java.math.BigDecimal
  * @param srcAccountId - id of account that initiated current withdrawal
  * @param withdrawalTime - time of withdrawal
  * @param destinationAddress - destination address
+ * @param sideChainFee - fee in sidechain(gas, mining fee, etc). null by default
  */
 data class WithdrawalFinalizationDetails(
     val withdrawalAmount: BigDecimal,
@@ -26,7 +27,8 @@ data class WithdrawalFinalizationDetails(
     val feeAssetId: String,
     val srcAccountId: String,
     val withdrawalTime: Long,
-    val destinationAddress: String
+    val destinationAddress: String,
+    val sideChainFee: BigDecimal? = null
 ) {
     /**
      * Transforms finalization details object into json string
@@ -39,7 +41,7 @@ data class WithdrawalFinalizationDetails(
          * Transforms given [json] into finalization details object
          * @return finalization details object
          */
-        fun fromJson(json: String) =
+        fun fromJson(json: String): WithdrawalFinalizationDetails =
             GsonInstance.get().fromJson(json, WithdrawalFinalizationDetails::class.java)
     }
 }

--- a/notifications/src/main/kotlin/com/d3/notifications/event/BasicEvents.kt
+++ b/notifications/src/main/kotlin/com/d3/notifications/event/BasicEvents.kt
@@ -25,35 +25,85 @@ open class BasicEvent(val id: String, val time: Long) {
  * Data class that holds transfer event data
  *
  * @param accountIdToNotify - account id that will be notified
- * @param type - type of event
  * @param amount - transfer amount
  * @param assetName - name of asset
  * @param id - event id
  * @param time - event time in milliseconds
- * @param description - description of transfer
- * @param from - defines the origin of transfer. null by default
- * @param to - defines the destination of transfer. null by default.
- * @param fee - fee to pay for transfer
  */
-class TransferNotifyEvent(
-    val type: TransferEventType,
+open class TransferNotifyEvent(
     val accountIdToNotify: String,
     val amount: BigDecimal,
     val assetName: String,
     id: String,
-    time: Long,
-    val description: String = "",
-    val from: String? = null,
-    val to: String? = null,
-    val fee: TransferFee? = null
+    time: Long
 ) : BasicEvent(id, time)
 
 /**
- * Type of transfer
+ * Client to client 'send' transfer event
  */
-enum class TransferEventType {
-    DEPOSIT, ROLLBACK, WITHDRAWAL, TRANSFER_RECEIVE, TRANSFER_SEND
-}
+class Client2ClientSendTransferEvent(
+    accountIdToNotify: String,
+    amount: BigDecimal,
+    assetName: String,
+    id: String,
+    time: Long,
+    val description: String,
+    val to: String,
+    val fee: TransferFee?
+) : TransferNotifyEvent(accountIdToNotify, amount, assetName, id, time)
+
+/**
+ * Client to client 'receive' transfer event
+ */
+class Client2ClientReceiveTransferEvent(
+    accountIdToNotify: String,
+    amount: BigDecimal,
+    assetName: String,
+    id: String,
+    time: Long,
+    val description: String,
+    val from: String,
+    val fee: TransferFee?
+) : TransferNotifyEvent(accountIdToNotify, amount, assetName, id, time)
+
+
+/**
+ * Deposit event
+ */
+class DepositTransferEvent(
+    accountIdToNotify: String,
+    amount: BigDecimal,
+    assetName: String,
+    id: String,
+    time: Long,
+    val from: String
+) : TransferNotifyEvent(accountIdToNotify, amount, assetName, id, time)
+
+/**
+ * Withdrawal event
+ */
+class WithdrawalTransferEvent(
+    accountIdToNotify: String,
+    amount: BigDecimal,
+    assetName: String,
+    id: String,
+    time: Long,
+    val to: String,
+    val fee: TransferFee?,
+    val sideChainFee: BigDecimal?
+) : TransferNotifyEvent(accountIdToNotify, amount, assetName, id, time)
+
+/**
+ * Rollback event
+ */
+class RollbackTransferEvent(
+    accountIdToNotify: String,
+    amount: BigDecimal,
+    assetName: String,
+    id: String,
+    time: Long,
+    val fee: TransferFee?
+) : TransferNotifyEvent(accountIdToNotify, amount, assetName, id, time)
 
 /**
  * Fee object

--- a/notifications/src/main/kotlin/com/d3/notifications/event/SoraEvents.kt
+++ b/notifications/src/main/kotlin/com/d3/notifications/event/SoraEvents.kt
@@ -34,13 +34,13 @@ class SoraDepositEvent(
     val from: String?
 ) : SoraEvent(id, time) {
     companion object {
-        fun map(transferNotifyEvent: TransferNotifyEvent) = SoraDepositEvent(
-            transferNotifyEvent.accountIdToNotify,
-            transferNotifyEvent.amount,
-            transferNotifyEvent.assetName,
-            transferNotifyEvent.id,
-            transferNotifyEvent.time,
-            transferNotifyEvent.from
+        fun map(transferNotifyEvent: DepositTransferEvent) = SoraDepositEvent(
+            accountIdToNotify = transferNotifyEvent.accountIdToNotify,
+            amount = transferNotifyEvent.amount,
+            assetName = transferNotifyEvent.assetName,
+            id = transferNotifyEvent.id,
+            time = transferNotifyEvent.time,
+            from = transferNotifyEvent.from
         )
     }
 }
@@ -52,17 +52,19 @@ class SoraWithdrawalEvent(
     val to: String,
     id: String,
     time: Long,
-    val fee: Fee?
+    val fee: Fee?,
+    val sideChainFee: BigDecimal?
 ) : SoraEvent(id, time) {
     companion object {
-        fun map(transferNotifyEvent: TransferNotifyEvent) = SoraWithdrawalEvent(
-            transferNotifyEvent.accountIdToNotify,
-            transferNotifyEvent.amount,
-            transferNotifyEvent.assetName,
-            transferNotifyEvent.to!!,
-            transferNotifyEvent.id,
-            transferNotifyEvent.time,
-            Fee.map(transferNotifyEvent.fee)
+        fun map(transferNotifyEvent: WithdrawalTransferEvent) = SoraWithdrawalEvent(
+            accountIdToNotify = transferNotifyEvent.accountIdToNotify,
+            amount = transferNotifyEvent.amount,
+            assetName = transferNotifyEvent.assetName,
+            to = transferNotifyEvent.to,
+            id = transferNotifyEvent.id,
+            time = transferNotifyEvent.time,
+            fee = Fee.map(transferNotifyEvent.fee),
+            sideChainFee = transferNotifyEvent.sideChainFee
         )
     }
 }
@@ -88,11 +90,11 @@ class SoraRegistrationEvent(
 ) : SoraEvent(id, time) {
     companion object {
         fun map(registrationNotifyEvent: RegistrationNotifyEvent) = SoraRegistrationEvent(
-            registrationNotifyEvent.accountId,
-            registrationNotifyEvent.address,
-            registrationNotifyEvent.subsystem.name,
-            registrationNotifyEvent.id,
-            registrationNotifyEvent.time
+            accountIdToNotify = registrationNotifyEvent.accountId,
+            address = registrationNotifyEvent.address,
+            subsystem = registrationNotifyEvent.subsystem.name,
+            id = registrationNotifyEvent.id,
+            time = registrationNotifyEvent.time
         )
     }
 }
@@ -105,10 +107,10 @@ class SoraFailedRegistrationEvent(
 ) : SoraEvent(id, time) {
     companion object {
         fun map(registrationNotifyEvent: FailedRegistrationNotifyEvent) = SoraFailedRegistrationEvent(
-            registrationNotifyEvent.accountId,
-            registrationNotifyEvent.subsystem.name,
-            registrationNotifyEvent.id,
-            registrationNotifyEvent.time
+            accountIdToNotify = registrationNotifyEvent.accountId,
+            subsystem = registrationNotifyEvent.subsystem.name,
+            id = registrationNotifyEvent.id,
+            time = registrationNotifyEvent.time
         )
     }
 }

--- a/notifications/src/main/kotlin/com/d3/notifications/handler/Client2ClientTransferCommandHandler.kt
+++ b/notifications/src/main/kotlin/com/d3/notifications/handler/Client2ClientTransferCommandHandler.kt
@@ -7,9 +7,9 @@ package com.d3.notifications.handler
 
 import com.d3.commons.provider.NotaryClientsProvider
 import com.d3.notifications.config.NotificationsConfig
-import com.d3.notifications.event.TransferEventType
+import com.d3.notifications.event.Client2ClientReceiveTransferEvent
+import com.d3.notifications.event.Client2ClientSendTransferEvent
 import com.d3.notifications.event.TransferFee
-import com.d3.notifications.event.TransferNotifyEvent
 import com.d3.notifications.queue.EventsQueue
 import iroha.protocol.TransactionOuterClass
 import jp.co.soramitsu.iroha.java.Utils
@@ -30,18 +30,17 @@ class Client2ClientTransferCommandHandler(
         val transferAsset = commandWithTx.command.transferAsset
         val tx = commandWithTx.tx
         val description: String = transferAsset.description ?: ""
-        val transferNotifyReceiveEvent = TransferNotifyEvent(
-            type = TransferEventType.TRANSFER_RECEIVE,
+        val transferNotifyReceiveEvent = Client2ClientReceiveTransferEvent(
             accountIdToNotify = transferAsset.destAccountId,
             amount = BigDecimal(transferAsset.amount),
             assetName = transferAsset.assetId,
             description = description,
             from = transferAsset.srcAccountId,
             id = Utils.toHex(Utils.hash(tx)) + "_receive",
-            time = tx.payload.reducedPayload.createdTime
+            time = tx.payload.reducedPayload.createdTime,
+            fee = getTransferFee(tx)
         )
-        val transferNotifySendEvent = TransferNotifyEvent(
-            type = TransferEventType.TRANSFER_SEND,
+        val transferNotifySendEvent = Client2ClientSendTransferEvent(
             accountIdToNotify = transferAsset.srcAccountId,
             amount = BigDecimal(transferAsset.amount),
             assetName = transferAsset.assetId,

--- a/notifications/src/main/kotlin/com/d3/notifications/handler/DepositCommandHandler.kt
+++ b/notifications/src/main/kotlin/com/d3/notifications/handler/DepositCommandHandler.kt
@@ -9,8 +9,7 @@ import com.d3.commons.provider.NotaryClientsProvider
 import com.d3.commons.sidechain.iroha.FEE_ROLLBACK_DESCRIPTION
 import com.d3.commons.sidechain.iroha.NOTARY_DOMAIN
 import com.d3.notifications.config.NotificationsConfig
-import com.d3.notifications.event.TransferEventType
-import com.d3.notifications.event.TransferNotifyEvent
+import com.d3.notifications.event.DepositTransferEvent
 import com.d3.notifications.queue.EventsQueue
 import jp.co.soramitsu.iroha.java.Utils
 import mu.KLogging
@@ -28,8 +27,7 @@ class DepositCommandHandler(
 ) : CommandHandler() {
     override fun handle(commandWithTx: CommandWithTx) {
         val transferAsset = commandWithTx.command.transferAsset
-        val transferNotifyEvent = TransferNotifyEvent(
-            type = TransferEventType.DEPOSIT,
+        val transferNotifyEvent = DepositTransferEvent(
             accountIdToNotify = transferAsset.destAccountId,
             amount = BigDecimal(transferAsset.amount),
             assetName = transferAsset.assetId,

--- a/notifications/src/main/kotlin/com/d3/notifications/handler/RollbackCommandHandler.kt
+++ b/notifications/src/main/kotlin/com/d3/notifications/handler/RollbackCommandHandler.kt
@@ -10,9 +10,8 @@ import com.d3.commons.sidechain.iroha.FEE_ROLLBACK_DESCRIPTION
 import com.d3.commons.sidechain.iroha.NOTARY_DOMAIN
 import com.d3.commons.sidechain.iroha.ROLLBACK_DESCRIPTION
 import com.d3.notifications.config.NotificationsConfig
-import com.d3.notifications.event.TransferEventType
+import com.d3.notifications.event.RollbackTransferEvent
 import com.d3.notifications.event.TransferFee
-import com.d3.notifications.event.TransferNotifyEvent
 import com.d3.notifications.queue.EventsQueue
 import iroha.protocol.Commands
 import iroha.protocol.TransactionOuterClass
@@ -32,8 +31,7 @@ class RollbackCommandHandler(
 ) : CommandHandler() {
     override fun handle(commandWithTx: CommandWithTx) {
         val transferAsset = commandWithTx.command.transferAsset
-        val transferNotifyEvent = TransferNotifyEvent(
-            type = TransferEventType.ROLLBACK,
+        val transferNotifyEvent = RollbackTransferEvent(
             accountIdToNotify = transferAsset.destAccountId,
             amount = BigDecimal(transferAsset.amount),
             assetName = transferAsset.assetId,
@@ -57,7 +55,6 @@ class RollbackCommandHandler(
                 && notaryClientsProvider.isClient(transferAsset.destAccountId).get()
         return depositSign && isRollbackSign(transferAsset)
     }
-
 
     /**
      * Returns withdrawal rollback fee

--- a/notifications/src/main/kotlin/com/d3/notifications/handler/WithdrawalCommandHandler.kt
+++ b/notifications/src/main/kotlin/com/d3/notifications/handler/WithdrawalCommandHandler.kt
@@ -9,9 +9,8 @@ import com.d3.commons.service.LAST_SUCCESSFUL_WITHDRAWAL_KEY
 import com.d3.commons.service.WithdrawalFinalizationDetails
 import com.d3.commons.sidechain.iroha.NOTARY_DOMAIN
 import com.d3.commons.util.irohaUnEscape
-import com.d3.notifications.event.TransferEventType
 import com.d3.notifications.event.TransferFee
-import com.d3.notifications.event.TransferNotifyEvent
+import com.d3.notifications.event.WithdrawalTransferEvent
 import com.d3.notifications.queue.EventsQueue
 import jp.co.soramitsu.iroha.java.Utils
 import org.springframework.stereotype.Component
@@ -32,15 +31,15 @@ class WithdrawalCommandHandler(private val eventsQueue: EventsQueue) : CommandHa
         } else {
             null
         }
-        val transferNotifyEvent = TransferNotifyEvent(
-            type = TransferEventType.WITHDRAWAL,
+        val transferNotifyEvent = WithdrawalTransferEvent(
             accountIdToNotify = withdrawalFinalizationDetails.srcAccountId,
             amount = withdrawalFinalizationDetails.withdrawalAmount,
             assetName = withdrawalFinalizationDetails.withdrawalAssetId,
             to = withdrawalFinalizationDetails.destinationAddress,
             fee = operationFee,
             id = Utils.toHex(Utils.hash(commandWithTx.tx)) + "_withdrawal",
-            time = commandWithTx.tx.payload.reducedPayload.createdTime
+            time = commandWithTx.tx.payload.reducedPayload.createdTime,
+            sideChainFee = withdrawalFinalizationDetails.sideChainFee
         )
         logger.info("Notify withdrawal $transferNotifyEvent")
         eventsQueue.enqueue(transferNotifyEvent)

--- a/notifications/src/main/kotlin/com/d3/notifications/service/EmailNotificationService.kt
+++ b/notifications/src/main/kotlin/com/d3/notifications/service/EmailNotificationService.kt
@@ -5,9 +5,7 @@
 
 package com.d3.notifications.service
 
-import com.d3.notifications.event.FailedRegistrationNotifyEvent
-import com.d3.notifications.event.RegistrationNotifyEvent
-import com.d3.notifications.event.TransferNotifyEvent
+import com.d3.notifications.event.*
 import com.d3.notifications.provider.D3ClientProvider
 import com.d3.notifications.smtp.SMTPService
 import com.github.kittinunf.result.Result
@@ -39,12 +37,8 @@ class EmailNotificationService(
         )
     }
 
-    override fun notifySendToClient(transferNotifyEvent: TransferNotifyEvent): Result<Unit, Exception> {
-        val toMessage = if (transferNotifyEvent.to != null) {
-            "to ${transferNotifyEvent.to} "
-        } else {
-            ""
-        }
+    override fun notifySendToClient(transferNotifyEvent: Client2ClientSendTransferEvent): Result<Unit, Exception> {
+        val toMessage = "to ${transferNotifyEvent.to} "
         val feeMessage = if (transferNotifyEvent.fee != null) {
             "Fee is ${transferNotifyEvent.fee.amount} ${transferNotifyEvent.fee.assetName}"
         } else {
@@ -58,12 +52,8 @@ class EmailNotificationService(
         )
     }
 
-    override fun notifyReceiveFromClient(transferNotifyEvent: TransferNotifyEvent): Result<Unit, Exception> {
-        val fromMessage = if (transferNotifyEvent.from != null) {
-            "from ${transferNotifyEvent.from} "
-        } else {
-            ""
-        }
+    override fun notifyReceiveFromClient(transferNotifyEvent: Client2ClientReceiveTransferEvent): Result<Unit, Exception> {
+        val fromMessage = "from ${transferNotifyEvent.from} "
         val message =
             "Dear client, transfer of ${transferNotifyEvent.amount} ${transferNotifyEvent.assetName} ${fromMessage}to your account ${transferNotifyEvent.accountIdToNotify} is successful.\n${transferNotifyEvent.description}"
         return checkClientAndSendMessage(
@@ -72,7 +62,7 @@ class EmailNotificationService(
         )
     }
 
-    override fun notifyRollback(transferNotifyEvent: TransferNotifyEvent): Result<Unit, Exception> {
+    override fun notifyRollback(transferNotifyEvent: RollbackTransferEvent): Result<Unit, Exception> {
         val feeMessage = if (transferNotifyEvent.fee == null) {
             ""
         } else {
@@ -80,20 +70,15 @@ class EmailNotificationService(
         }
         val message =
             "Dear client, unfortunately, we failed to withdraw ${transferNotifyEvent.amount} ${transferNotifyEvent.assetName} from your account ${transferNotifyEvent.accountIdToNotify}. " +
-                    "Rollback has been executed, so your money is going back to your account. $feeMessage\n" +
-                    transferNotifyEvent.description
+                    "Rollback has been executed, so your money is going back to your account. $feeMessage\n"
         return checkClientAndSendMessage(
             transferNotifyEvent.accountIdToNotify,
             D3_ROLLBACK_SUBJECT, message
         )
     }
 
-    override fun notifyDeposit(transferNotifyEvent: TransferNotifyEvent): Result<Unit, Exception> {
-        val fromMessage = if (transferNotifyEvent.from != null) {
-            "from ${transferNotifyEvent.from} "
-        } else {
-            ""
-        }
+    override fun notifyDeposit(transferNotifyEvent: DepositTransferEvent): Result<Unit, Exception> {
+        val fromMessage = "from ${transferNotifyEvent.from} "
         val message =
             "Dear client, deposit of ${transferNotifyEvent.amount} ${transferNotifyEvent.assetName} ${fromMessage}to your account ${transferNotifyEvent.accountIdToNotify} is successful."
         return checkClientAndSendMessage(
@@ -102,19 +87,15 @@ class EmailNotificationService(
         )
     }
 
-    override fun notifyWithdrawal(transferNotifyEvent: TransferNotifyEvent): Result<Unit, Exception> {
-        val toMessage = if (transferNotifyEvent.to != null) {
-            "to ${transferNotifyEvent.to} "
-        } else {
-            ""
-        }
+    override fun notifyWithdrawal(transferNotifyEvent: WithdrawalTransferEvent): Result<Unit, Exception> {
+        val toMessage = "to ${transferNotifyEvent.to} "
         val feeMessage = if (transferNotifyEvent.fee != null) {
             "Fee is ${transferNotifyEvent.fee.amount} ${transferNotifyEvent.fee.assetName}"
         } else {
             ""
         }
         val message =
-            "Dear client, withdrawal of ${transferNotifyEvent.amount} ${transferNotifyEvent.assetName} ${toMessage}from your account ${transferNotifyEvent.accountIdToNotify} is successful. ${transferNotifyEvent.description}\n$feeMessage"
+            "Dear client, withdrawal of ${transferNotifyEvent.amount} ${transferNotifyEvent.assetName} ${toMessage}from your account ${transferNotifyEvent.accountIdToNotify} to ${transferNotifyEvent.to} is successful.\n$feeMessage"
         return checkClientAndSendMessage(
             transferNotifyEvent.accountIdToNotify,
             D3_WITHDRAWAL_EMAIL_SUBJECT, message

--- a/notifications/src/main/kotlin/com/d3/notifications/service/NotificationService.kt
+++ b/notifications/src/main/kotlin/com/d3/notifications/service/NotificationService.kt
@@ -5,9 +5,7 @@
 
 package com.d3.notifications.service
 
-import com.d3.notifications.event.FailedRegistrationNotifyEvent
-import com.d3.notifications.event.RegistrationNotifyEvent
-import com.d3.notifications.event.TransferNotifyEvent
+import com.d3.notifications.event.*
 import com.github.kittinunf.result.Result
 
 /**
@@ -19,35 +17,35 @@ interface NotificationService {
      * @param transferNotifyEvent - transfer event
      * @return result of operation
      * */
-    fun notifyDeposit(transferNotifyEvent: TransferNotifyEvent): Result<Unit, Exception>
+    fun notifyDeposit(transferNotifyEvent: DepositTransferEvent): Result<Unit, Exception>
 
     /**
      * Notifies client about withdrawal event
      * @param transferNotifyEvent - transfer event
      * @return result of operation
      * */
-    fun notifyWithdrawal(transferNotifyEvent: TransferNotifyEvent): Result<Unit, Exception>
+    fun notifyWithdrawal(transferNotifyEvent: WithdrawalTransferEvent): Result<Unit, Exception>
 
     /**
      * Notifies client about sent transfer
      * @param transferNotifyEvent - transfer event
      * @return result of operation
      * */
-    fun notifySendToClient(transferNotifyEvent: TransferNotifyEvent): Result<Unit, Exception>
+    fun notifySendToClient(transferNotifyEvent: Client2ClientSendTransferEvent): Result<Unit, Exception>
 
     /**
      * Notifies client about received transfer
      * @param transferNotifyEvent - transfer event
      * @return result of operation
      * */
-    fun notifyReceiveFromClient(transferNotifyEvent: TransferNotifyEvent): Result<Unit, Exception>
+    fun notifyReceiveFromClient(transferNotifyEvent: Client2ClientReceiveTransferEvent): Result<Unit, Exception>
 
     /**
      * Notifies client about rollback event
      * @param transferNotifyEvent - transfer event
      * @return result of operation
      * */
-    fun notifyRollback(transferNotifyEvent: TransferNotifyEvent): Result<Unit, Exception>
+    fun notifyRollback(transferNotifyEvent: RollbackTransferEvent): Result<Unit, Exception>
 
     /**
      * Notifies client about registration event

--- a/notifications/src/main/kotlin/com/d3/notifications/service/PushNotificationService.kt
+++ b/notifications/src/main/kotlin/com/d3/notifications/service/PushNotificationService.kt
@@ -5,9 +5,7 @@
 
 package com.d3.notifications.service
 
-import com.d3.notifications.event.FailedRegistrationNotifyEvent
-import com.d3.notifications.event.RegistrationNotifyEvent
-import com.d3.notifications.event.TransferNotifyEvent
+import com.d3.notifications.event.*
 import com.d3.notifications.push.WebPushAPIService
 import com.github.kittinunf.result.Result
 
@@ -30,35 +28,35 @@ class PushNotificationService(private val webPushAPIService: WebPushAPIService) 
         )
     }
 
-    override fun notifySendToClient(transferNotifyEvent: TransferNotifyEvent): Result<Unit, Exception> {
+    override fun notifySendToClient(transferNotifyEvent: Client2ClientSendTransferEvent): Result<Unit, Exception> {
         return webPushAPIService.push(
             transferNotifyEvent.accountIdToNotify,
             "Transfer of ${transferNotifyEvent.amount} ${transferNotifyEvent.assetName}"
         )
     }
 
-    override fun notifyReceiveFromClient(transferNotifyEvent: TransferNotifyEvent): Result<Unit, Exception> {
+    override fun notifyReceiveFromClient(transferNotifyEvent: Client2ClientReceiveTransferEvent): Result<Unit, Exception> {
         return webPushAPIService.push(
             transferNotifyEvent.accountIdToNotify,
             "Transfer of ${transferNotifyEvent.amount} ${transferNotifyEvent.assetName}"
         )
     }
 
-    override fun notifyRollback(transferNotifyEvent: TransferNotifyEvent): Result<Unit, Exception> {
+    override fun notifyRollback(transferNotifyEvent: RollbackTransferEvent): Result<Unit, Exception> {
         return webPushAPIService.push(
             transferNotifyEvent.accountIdToNotify,
             "Rollback of ${transferNotifyEvent.amount} ${transferNotifyEvent.assetName}"
         )
     }
 
-    override fun notifyWithdrawal(transferNotifyEvent: TransferNotifyEvent): Result<Unit, Exception> {
+    override fun notifyWithdrawal(transferNotifyEvent: WithdrawalTransferEvent): Result<Unit, Exception> {
         return webPushAPIService.push(
             transferNotifyEvent.accountIdToNotify,
             "Withdrawal of ${transferNotifyEvent.amount} ${transferNotifyEvent.assetName}"
         )
     }
 
-    override fun notifyDeposit(transferNotifyEvent: TransferNotifyEvent): Result<Unit, Exception> {
+    override fun notifyDeposit(transferNotifyEvent: DepositTransferEvent): Result<Unit, Exception> {
         return webPushAPIService.push(
             transferNotifyEvent.accountIdToNotify,
             "Deposit of ${transferNotifyEvent.amount} ${transferNotifyEvent.assetName}"

--- a/notifications/src/main/kotlin/com/d3/notifications/service/SoraNotificationService.kt
+++ b/notifications/src/main/kotlin/com/d3/notifications/service/SoraNotificationService.kt
@@ -31,7 +31,7 @@ class SoraNotificationService(private val soraConfig: SoraConfig) : Notification
         }
     }
 
-    override fun notifyDeposit(transferNotifyEvent: TransferNotifyEvent): Result<Unit, Exception> {
+    override fun notifyDeposit(transferNotifyEvent: DepositTransferEvent): Result<Unit, Exception> {
         if (transferNotifyEvent.assetName != ETH_ASSET_ID) {
             return Result.of { logger.warn("Sora notification service is not interested in ${transferNotifyEvent.assetName} deposits") }
         }
@@ -41,7 +41,7 @@ class SoraNotificationService(private val soraConfig: SoraConfig) : Notification
         }
     }
 
-    override fun notifyWithdrawal(transferNotifyEvent: TransferNotifyEvent): Result<Unit, Exception> {
+    override fun notifyWithdrawal(transferNotifyEvent: WithdrawalTransferEvent): Result<Unit, Exception> {
         if (transferNotifyEvent.assetName != ETH_ASSET_ID) {
             return Result.of { logger.warn("Sora notification service is not interested in ${transferNotifyEvent.assetName} withdrawals") }
         }
@@ -51,21 +51,21 @@ class SoraNotificationService(private val soraConfig: SoraConfig) : Notification
         }
     }
 
-    override fun notifySendToClient(transferNotifyEvent: TransferNotifyEvent): Result<Unit, Exception> {
+    override fun notifySendToClient(transferNotifyEvent: Client2ClientSendTransferEvent): Result<Unit, Exception> {
         logger.info("Notify Sora transfer send $transferNotifyEvent")
         return Result.of {
             logger.warn("'Transfer send' notifications are not supported in Sora")
         }
     }
 
-    override fun notifyReceiveFromClient(transferNotifyEvent: TransferNotifyEvent): Result<Unit, Exception> {
+    override fun notifyReceiveFromClient(transferNotifyEvent: Client2ClientReceiveTransferEvent): Result<Unit, Exception> {
         logger.info("Notify Sora transfer receive $transferNotifyEvent")
         return Result.of {
             logger.warn("'Transfer receive' notifications are not supported in Sora")
         }
     }
 
-    override fun notifyRollback(transferNotifyEvent: TransferNotifyEvent): Result<Unit, Exception> {
+    override fun notifyRollback(transferNotifyEvent: RollbackTransferEvent): Result<Unit, Exception> {
         logger.info("Notify Sora rollback $transferNotifyEvent")
         return Result.of {
             logger.warn("Rollback notifications are not supported in Sora")


### PR DESCRIPTION
### Description of the Change
Now we can set 'gas' or mining fee in a field `sideChainFee:BigDecimal?`. This value is set on the withdrawal finalization phase. It's null by default.
Plus model refactor.