### PR TITLE
Check accounts in notifications

### DIFF
--- a/notifications-integration-test/src/integration-test/kotlin/notifications/NotificationsIntegrationTest.kt
+++ b/notifications-integration-test/src/integration-test/kotlin/notifications/NotificationsIntegrationTest.kt
@@ -503,11 +503,11 @@ class NotificationsIntegrationTest {
             D3_CLIENT_ENABLE_NOTIFICATIONS,
             "true"
         ).map {
-            val notaryAccount = integrationHelper.accountHelper.notaryAccount
+            val withdrawalAccount = integrationHelper.accountHelper.ethWithdrawalAccount
             integrationHelper.transferAssetIrohaFromClient(
-                notaryAccount.accountId,
-                notaryAccount.keyPair,
-                notaryAccount.accountId,
+                withdrawalAccount.accountId,
+                withdrawalAccount.keyPair,
+                withdrawalAccount.accountId,
                 environment.srcClientId,
                 ETH_ASSET_ID,
                 ROLLBACK_DESCRIPTION,
@@ -543,17 +543,17 @@ class NotificationsIntegrationTest {
             D3_CLIENT_ENABLE_NOTIFICATIONS,
             "true"
         ).map {
-            val notaryAccount = integrationHelper.accountHelper.notaryAccount
-            val tx = Transaction.builder(notaryAccount.accountId)
+            val withdrawalAccount = integrationHelper.accountHelper.ethWithdrawalAccount
+            val tx = Transaction.builder(withdrawalAccount.accountId)
                 .transferAsset(
-                    notaryAccount.accountId,
+                    withdrawalAccount.accountId,
                     environment.srcClientId,
                     ETH_ASSET_ID,
                     ROLLBACK_DESCRIPTION,
                     rollbackValue.toPlainString()
                 )
                 .transferAsset(
-                    notaryAccount.accountId,
+                    withdrawalAccount.accountId,
                     environment.srcClientId,
                     ETH_ASSET_ID,
                     FEE_ROLLBACK_DESCRIPTION,
@@ -561,7 +561,7 @@ class NotificationsIntegrationTest {
                 )
                 .setCreatedTime(System.currentTimeMillis())
                 .setQuorum(1)
-                .sign(notaryAccount.keyPair)
+                .sign(withdrawalAccount.keyPair)
                 .build()
             integrationHelper.irohaConsumer.send(tx).get()
         }.map {

--- a/notifications-integration-test/src/integration-test/kotlin/notifications/environment/NotificationsIntegrationTestEnvironment.kt
+++ b/notifications-integration-test/src/integration-test/kotlin/notifications/environment/NotificationsIntegrationTestEnvironment.kt
@@ -151,7 +151,7 @@ class NotificationsIntegrationTestEnvironment(private val integrationHelper: Iro
                 EthRegistrationCommandHandler(eventsQueue, notaryClientsProvider, notificationsConfig),
                 BtcRegistrationCommandHandler(eventsQueue, notaryClientsProvider, notificationsConfig),
                 RollbackCommandHandler(notificationsConfig, notaryClientsProvider, eventsQueue),
-                WithdrawalCommandHandler(eventsQueue),
+                WithdrawalCommandHandler(notificationsConfig, eventsQueue),
                 EthProofsCollectedCommandHandler()
             )
         )

--- a/notifications-integration-test/src/main/kotlin/integration/helper/NotificationsConfigHelper.kt
+++ b/notifications-integration-test/src/main/kotlin/integration/helper/NotificationsConfigHelper.kt
@@ -22,6 +22,10 @@ class NotificationsConfigHelper(private val accountHelper: IrohaAccountHelper) :
             NotificationsConfig::class.java, "notifications.properties"
         )
         return object : NotificationsConfig {
+            override val ethWithdrawalAccount = accountHelper.ethWithdrawalAccount.accountId
+            override val btcWithdrawalAccount = accountHelper.btcWithdrawalAccount.accountId
+            override val ethDepositAccount = accountHelper.notaryAccount.accountId
+            override val btcDepositAccount = accountHelper.notaryAccount.accountId
             override val ethRegistrationServiceAccount = accountHelper.ethRegistrationAccount.accountId
             override val btcRegistrationServiceAccount = accountHelper.btcRegistrationAccount.accountId
             override val rmq = notificationsConfig.rmq

--- a/notifications/src/main/kotlin/com/d3/notifications/config/NotificationsConfig.kt
+++ b/notifications/src/main/kotlin/com/d3/notifications/config/NotificationsConfig.kt
@@ -37,6 +37,14 @@ interface NotificationsConfig {
     val ethRegistrationServiceAccount: String
     // Bitcoin registration service Iroha account id
     val btcRegistrationServiceAccount: String
+    // Eth withdrawal account
+    val ethWithdrawalAccount: String
+    // Btc withdrawal account
+    val btcWithdrawalAccount: String
+    // Eth deposit account
+    val ethDepositAccount: String
+    // Btc deposit account
+    val btcDepositAccount: String
 }
 
 /**

--- a/notifications/src/main/kotlin/com/d3/notifications/handler/DepositCommandHandler.kt
+++ b/notifications/src/main/kotlin/com/d3/notifications/handler/DepositCommandHandler.kt
@@ -7,7 +7,6 @@ package com.d3.notifications.handler
 
 import com.d3.commons.provider.NotaryClientsProvider
 import com.d3.commons.sidechain.iroha.FEE_ROLLBACK_DESCRIPTION
-import com.d3.commons.sidechain.iroha.NOTARY_DOMAIN
 import com.d3.notifications.config.NotificationsConfig
 import com.d3.notifications.event.DepositTransferEvent
 import com.d3.notifications.queue.EventsQueue
@@ -44,9 +43,9 @@ class DepositCommandHandler(
             return false
         }
         val transferAsset = commandWithTx.command.transferAsset
-        //TODO be more precise
+
         val depositSign =
-            transferAsset.srcAccountId.endsWith("@$NOTARY_DOMAIN")
+            (transferAsset.srcAccountId == notificationsConfig.ethDepositAccount || transferAsset.srcAccountId == notificationsConfig.btcDepositAccount)
                     && transferAsset.destAccountId != notificationsConfig.transferBillingAccount
                     && transferAsset.destAccountId != notificationsConfig.withdrawalBillingAccount
                     && notaryClientsProvider.isClient(transferAsset.destAccountId).get()

--- a/notifications/src/main/kotlin/com/d3/notifications/handler/RollbackCommandHandler.kt
+++ b/notifications/src/main/kotlin/com/d3/notifications/handler/RollbackCommandHandler.kt
@@ -48,11 +48,11 @@ class RollbackCommandHandler(
             return false
         }
         val transferAsset = commandWithTx.command.transferAsset
-        //TODO be more precise
-        val depositSign = transferAsset.srcAccountId.endsWith("@$NOTARY_DOMAIN")
-                && transferAsset.destAccountId != notificationsConfig.transferBillingAccount
-                && transferAsset.destAccountId != notificationsConfig.withdrawalBillingAccount
-                && notaryClientsProvider.isClient(transferAsset.destAccountId).get()
+        val depositSign =
+            (transferAsset.srcAccountId == notificationsConfig.btcWithdrawalAccount || transferAsset.srcAccountId == notificationsConfig.ethWithdrawalAccount)
+                    && transferAsset.destAccountId != notificationsConfig.transferBillingAccount
+                    && transferAsset.destAccountId != notificationsConfig.withdrawalBillingAccount
+                    && notaryClientsProvider.isClient(transferAsset.destAccountId).get()
         return depositSign && isRollbackSign(transferAsset)
     }
 

--- a/notifications/src/main/kotlin/com/d3/notifications/handler/WithdrawalCommandHandler.kt
+++ b/notifications/src/main/kotlin/com/d3/notifications/handler/WithdrawalCommandHandler.kt
@@ -7,8 +7,8 @@ package com.d3.notifications.handler
 
 import com.d3.commons.service.LAST_SUCCESSFUL_WITHDRAWAL_KEY
 import com.d3.commons.service.WithdrawalFinalizationDetails
-import com.d3.commons.sidechain.iroha.NOTARY_DOMAIN
 import com.d3.commons.util.irohaUnEscape
+import com.d3.notifications.config.NotificationsConfig
 import com.d3.notifications.event.TransferFee
 import com.d3.notifications.event.WithdrawalTransferEvent
 import com.d3.notifications.queue.EventsQueue
@@ -20,7 +20,10 @@ import java.math.BigDecimal
  * Handler that handles withdrawal commands
  */
 @Component
-class WithdrawalCommandHandler(private val eventsQueue: EventsQueue) : CommandHandler() {
+class WithdrawalCommandHandler(
+    private val notificationsConfig: NotificationsConfig,
+    private val eventsQueue: EventsQueue
+) : CommandHandler() {
 
     // Handles withdrawal event notification
     override fun handle(commandWithTx: CommandWithTx) {
@@ -52,9 +55,8 @@ class WithdrawalCommandHandler(private val eventsQueue: EventsQueue) : CommandHa
         }
         val setAccountDetail = commandWithTx.command.setAccountDetail
         val storageAccountId = setAccountDetail.accountId
-        return storageAccountId.endsWith("@$NOTARY_DOMAIN") &&
+        return (storageAccountId == notificationsConfig.btcWithdrawalAccount || storageAccountId == notificationsConfig.ethWithdrawalAccount) &&
                 setAccountDetail.key == LAST_SUCCESSFUL_WITHDRAWAL_KEY &&
                 storageAccountId == commandWithTx.tx.getCreator()
     }
-
 }

--- a/notifications/src/main/resources/notifications.properties
+++ b/notifications/src/main/resources/notifications.properties
@@ -6,6 +6,10 @@ notifications.registrationServiceAccountName=registration_service
 notifications.webPort=8452
 notifications.ethRegistrationServiceAccount=eth_registration_service@notary
 notifications.btcRegistrationServiceAccount=btc_registration_service@notary
+notifications.ethWithdrawalAccount=withdrawal@notary
+notifications.btcWithdrawalAccount=btc_withdrawal_service@notary
+notifications.ethDepositAccount=notary@notary
+notifications.btcDepositAccount=notary@notary
 # --------- RMQ ---------
 notifications.rmq.host=d3-rmq
 notifications.rmq.port=5672


### PR DESCRIPTION
### Description of the Change
It's not enough to check domain only to determine deposit and withdrawal events. We have to check the whole account id.