### PR TITLE
Update GB for notary@notary

### DIFF
--- a/deploy/iroha/genesis.block
+++ b/deploy/iroha/genesis.block
@@ -34,7 +34,8 @@
                     "can_grant_can_set_my_quorum",
                     "can_grant_can_add_my_signatory",
                     "can_grant_can_transfer_my_assets",
-                    "can_get_peers"
+                    "can_get_peers",
+                    "can_create_account"
                   ]
                 }
               },


### PR DESCRIPTION
### Description of the Change
We need `can_create_account` permission for notary to create withdrawal proof storage.