### PR TITLE
Basic auth in notification service

### DIFF
--- a/notifications/src/main/kotlin/com/d3/notifications/config/NotificationsConfig.kt
+++ b/notifications/src/main/kotlin/com/d3/notifications/config/NotificationsConfig.kt
@@ -67,6 +67,10 @@ interface SMTPConfig {
 interface SoraConfig {
     // URL of REST service that is used to send notifications to Sora. Must contain protocol.
     val notificationServiceURL: String
+    // Sora notification service basic auth login
+    val notificationServiceLogin: String
+    // Sora notification service basic auth password
+    val notificationServicePassword: String
 }
 
 /**

--- a/notifications/src/main/kotlin/com/d3/notifications/service/SoraNotificationService.kt
+++ b/notifications/src/main/kotlin/com/d3/notifications/service/SoraNotificationService.kt
@@ -9,6 +9,7 @@ import com.d3.notifications.config.SoraConfig
 import com.d3.notifications.event.*
 import com.github.kittinunf.result.Result
 import mu.KLogging
+import org.apache.commons.codec.binary.Base64
 import org.json.JSONObject
 
 const val ETH_ASSET_ID = "ether#ethereum"
@@ -101,7 +102,14 @@ class SoraNotificationService(private val soraConfig: SoraConfig) : Notification
     private fun postSoraEvent(uri: SoraURI, event: SoraEvent) {
         //TODO handle repeatable exceptions
         val url = soraConfig.notificationServiceURL + "/" + uri.uri
-        val response = khttp.post(url = url, json = JSONObject(event))
+
+        //Basic auth
+        val basicAuthHeader = HashMap<String, String>()
+        val credentials: String =
+            Base64.encodeBase64String((soraConfig.notificationServiceLogin + ":" + soraConfig.notificationServicePassword).toByteArray())
+        basicAuthHeader["Authorization"] = "Basic $credentials"
+
+        val response = khttp.post(url = url, json = JSONObject(event), headers = basicAuthHeader)
         if (response.statusCode == 200) {
             logger.info("Sora event $event has been successfully posted")
         } else {

--- a/notifications/src/main/resources/sora.properties
+++ b/notifications/src/main/resources/sora.properties
@@ -1,2 +1,4 @@
 # --------- Sora API -------
 notifications.sora.notificationServiceURL=http://localhost:8452/sora
+notifications.sora.notificationServiceLogin=user
+notifications.sora.notificationServicePassword=password


### PR DESCRIPTION
### Description of the Change
Sore uses basic auth so we have to provide basic auth credentials.