### PR TITLE
Scale notifications using RMQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,4 +45,5 @@ smtp.password=ask maintainers
 127.0.0.1 d3-rmq
 127.0.0.1 d3-brvs
 127.0.0.1 d3-brvs-mongodb
+127.0.0.1 d3-rmq-notification-balancer
 ```

--- a/deploy/docker-compose.ci.yml
+++ b/deploy/docker-compose.ci.yml
@@ -34,6 +34,13 @@ services:
     networks:
     - d3-notary
 
+  d3-notification-deduplication-rmq:
+    container_name: d3-notification-deduplication-rmq-${SUBNET}
+    expose:
+      - 5672
+    networks:
+      - d3-notary
+
   d3-chain-adapter:
     container_name: d3-chain-adapter-${SUBNET}
     networks:

--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -41,12 +41,21 @@ services:
     networks:
       - d3-network
 
+  d3-notification-deduplication-rmq:
+    ports:
+      - 25672:5672
+    networks:
+      - d3-network
+
   d3-rmq:
     ports:
       - 8181:15672
       - 5672:5672
     networks:
       - d3-network
+
+  ports:
+    - 25672:5672
 
   d3-chain-adapter:
     environment:

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -49,6 +49,17 @@ services:
     networks:
       - d3-network
 
+
+  d3-notification-deduplication-rmq:
+    # TODO change to image from Soramitsu nexus
+    image: dolgopolovwork/d3-notification-deduplication-rmq
+    container_name: d3-notification-deduplication-rmq
+    environment:
+      RABBITMQ_DEFAULT_USER: user
+      RABBITMQ_DEFAULT_PASS: password
+    networks:
+      - d3-network
+
   d3-chain-adapter:
     image: nexus.iroha.tech:19004/soramitsu/chain-adapter:develop
     container_name: d3-chain-adapter

--- a/notifications-integration-test/src/integration-test/kotlin/notifications/NotificationStartupIntegrationTest.kt
+++ b/notifications-integration-test/src/integration-test/kotlin/notifications/NotificationStartupIntegrationTest.kt
@@ -1,9 +1,15 @@
 package notifications
 
+import com.d3.commons.config.loadRawLocalConfigs
+import com.d3.notifications.config.NotificationsConfig
 import integration.helper.ContainerHelper
 import integration.helper.DEFAULT_RMQ_PORT
+import integration.helper.KGenericContainer
 import org.junit.Assert.assertTrue
-import org.junit.jupiter.api.*
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class NotificationStartupIntegrationTest {
@@ -11,9 +17,16 @@ class NotificationStartupIntegrationTest {
     private val containerHelper = ContainerHelper()
     private val dockerfile = "${containerHelper.userDir}/notifications/build/docker/Dockerfile"
     private val contextFolder = "${containerHelper.userDir}/notifications/build/docker"
+    private val balancerRmqContainer =
+        KGenericContainer("dolgopolovwork/d3-notification-deduplication-rmq").withExposedPorts(DEFAULT_RMQ_PORT)
 
     // Create notification service container
     private val notificationServiceContainer = containerHelper.createSoraPluginContainer(contextFolder, dockerfile)
+
+    private val notificationsConfig = loadRawLocalConfigs(
+        "notifications",
+        NotificationsConfig::class.java, "notifications.properties"
+    )
 
     @BeforeAll
     fun setUp() {
@@ -23,6 +36,13 @@ class NotificationStartupIntegrationTest {
         // Start RMQ
         containerHelper.rmqContainer.start()
 
+        // Set RMQ credentials
+        balancerRmqContainer
+            .withEnv("RABBITMQ_DEFAULT_USER", notificationsConfig.balancerRMQ.username!!)
+            .withEnv("RABBITMQ_DEFAULT_PASS", notificationsConfig.balancerRMQ.password!!)
+
+        balancerRmqContainer.start()
+
         notificationServiceContainer.addEnv(
             "NOTIFICATIONS__IROHA_HOSTNAME",
             containerHelper.irohaContainer.toriiAddress.host
@@ -31,9 +51,13 @@ class NotificationStartupIntegrationTest {
             "NOTIFICATIONS__IROHA_PORT",
             containerHelper.irohaContainer.toriiAddress.port.toString()
         )
-        notificationServiceContainer.addEnv("NOTIFICATIONS_RMQ_HOST", "127.0.0.1")
+        notificationServiceContainer.addEnv("NOTIFICATIONS_LOCALRMQ_HOST", "127.0.0.1")
         notificationServiceContainer.addEnv(
-            "NOTIFICATIONS_RMQ_PORT", containerHelper.rmqContainer.getMappedPort(DEFAULT_RMQ_PORT).toString()
+            "NOTIFICATIONS_LOCALRMQ_PORT", containerHelper.rmqContainer.getMappedPort(DEFAULT_RMQ_PORT).toString()
+        )
+        notificationServiceContainer.addEnv("NOTIFICATIONS_BALANCERRMQ_HOST", "127.0.0.1")
+        notificationServiceContainer.addEnv(
+            "NOTIFICATIONS_BALANCERRMQ_PORT", balancerRmqContainer.getMappedPort(DEFAULT_RMQ_PORT).toString()
         )
 
         notificationServiceContainer.start()
@@ -43,6 +67,7 @@ class NotificationStartupIntegrationTest {
     @AfterAll
     fun tearDown() {
         containerHelper.close()
+        balancerRmqContainer.stop()
         notificationServiceContainer.stop()
     }
 

--- a/notifications-integration-test/src/integration-test/kotlin/notifications/environment/NotificationsIntegrationTestEnvironment.kt
+++ b/notifications-integration-test/src/integration-test/kotlin/notifications/environment/NotificationsIntegrationTestEnvironment.kt
@@ -81,7 +81,7 @@ class NotificationsIntegrationTestEnvironment(private val integrationHelper: Iro
         createPrettySingleThreadPool(NOTIFICATIONS_SERVICE_NAME, "iroha-chain-listener")
 
     private val irohaChainListener = ReliableIrohaChainListener(
-        rmqConfig = notificationsConfig.rmq,
+        rmqConfig = notificationsConfig.localRMQ,
         irohaQueue = notificationsConfig.blocksQueue,
         autoAck = false,
         consumerExecutorService = chainListenerExecutorService
@@ -138,7 +138,7 @@ class NotificationsIntegrationTestEnvironment(private val integrationHelper: Iro
     private val eventsQueue =
         EventsQueue(
             listOf(emailNotificationService, pushNotificationService, soraNotificationService),
-            notificationsConfig.rmq
+            notificationsConfig.balancerRMQ
         )
 
     val notificationInitialization =

--- a/notifications-integration-test/src/main/kotlin/integration/helper/NotificationsConfigHelper.kt
+++ b/notifications-integration-test/src/main/kotlin/integration/helper/NotificationsConfigHelper.kt
@@ -5,6 +5,7 @@
 
 package integration.helper
 
+import com.d3.chainadapter.client.RMQConfig
 import com.d3.commons.config.loadRawLocalConfigs
 import com.d3.commons.registration.NotaryRegistrationConfig
 import com.d3.commons.util.getRandomString
@@ -22,6 +23,13 @@ class NotificationsConfigHelper(private val accountHelper: IrohaAccountHelper) :
             NotificationsConfig::class.java, "notifications.properties"
         )
         return object : NotificationsConfig {
+            override val balancerRMQ = object : RMQConfig {
+                override val host = notificationsConfig.balancerRMQ.host
+                override val irohaExchange = notificationsConfig.balancerRMQ.irohaExchange
+                override val port = 5672
+                override val password = notificationsConfig.balancerRMQ.password
+                override val username = notificationsConfig.balancerRMQ.username
+            }
             override val ethWithdrawalProofSetter = accountHelper.ethWithdrawalProofSetter.accountId
             // No matter what port. It's not used in integration tests
             override val healthCheckPort = 12345
@@ -31,7 +39,7 @@ class NotificationsConfigHelper(private val accountHelper: IrohaAccountHelper) :
             override val btcDepositAccount = accountHelper.notaryAccount.accountId
             override val ethRegistrationServiceAccount = accountHelper.ethRegistrationAccount.accountId
             override val btcRegistrationServiceAccount = accountHelper.btcRegistrationAccount.accountId
-            override val rmq = notificationsConfig.rmq
+            override val localRMQ = notificationsConfig.localRMQ
             override val blocksQueue = String.getRandomString(10)
             override val irohaQueryTimeoutMls = notificationsConfig.irohaQueryTimeoutMls
             override val registrationServiceAccountName =

--- a/notifications/src/main/kotlin/com/d3/notifications/config/NotificationAppConfiguration.kt
+++ b/notifications/src/main/kotlin/com/d3/notifications/config/NotificationAppConfiguration.kt
@@ -59,14 +59,14 @@ class NotificationAppConfiguration {
 
     @Bean
     fun irohaChainListener() = ReliableIrohaChainListener(
-        rmqConfig = notificationsConfig.rmq,
+        rmqConfig = notificationsConfig.localRMQ,
         irohaQueue = notificationsConfig.blocksQueue,
         autoAck = false,
         consumerExecutorService = chainListenerExecutorService()
     )
 
     @Bean
-    fun rmqConfig() = notificationsConfig.rmq
+    fun balancerRMQConfig() = notificationsConfig.balancerRMQ
 
     @Bean
     fun notificationsConfig() = notificationsConfig

--- a/notifications/src/main/kotlin/com/d3/notifications/config/NotificationsConfig.kt
+++ b/notifications/src/main/kotlin/com/d3/notifications/config/NotificationsConfig.kt
@@ -29,8 +29,10 @@ interface NotificationsConfig {
     val clientStorageAccount: String
     // Account name of registration service(no domain)
     val registrationServiceAccountName: String
-    // RMQ configuration
-    val rmq: RMQConfig
+    // Local RMQ configuration. Used to work with chain-adapter
+    val localRMQ: RMQConfig
+    // Remote balancer RMQ configuration.
+    val balancerRMQ: RMQConfig
     // Queue name
     val blocksQueue: String
     // Timeout for Iroha queries

--- a/notifications/src/main/resources/notifications.properties
+++ b/notifications/src/main/resources/notifications.properties
@@ -16,10 +16,18 @@ notifications.ethDepositAccount=notary@notary
 notifications.btcDepositAccount=notary@notary
 # --------- Eth withdrawal proof setter account ---------
 notifications.ethWithdrawalProofSetter=withdrawal@notary
+# --------- Local RMQ ---------
+notifications.localRMQ.host=d3-rmq
+notifications.localRMQ.port=5672
+notifications.localRMQ.irohaExchange=iroha
 # --------- RMQ ---------
-notifications.rmq.host=d3-rmq
-notifications.rmq.port=5672
-notifications.rmq.irohaExchange=iroha
+notifications.balancerRMQ.host=d3-notification-deduplication-rmq
+notifications.balancerRMQ.port=25672
+# TODO this param is not needed
+notifications.balancerRMQ.irohaExchange=iroha
+notifications.balancerRMQ.username=user
+notifications.balancerRMQ.password=password
+# -----------------------
 notifications.blocksQueue=notifications_queue
 notifications.irohaQueryTimeoutMls=60000
 # --------- Iroha ---------


### PR DESCRIPTION
### Description of the Change
Now we can scale notifications using one extra RMQ instance with [deduplication plugin](https://github.com/noxdafox/rabbitmq-message-deduplication) being installed.