### PR TITLE
Put notification model in a separate project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ hs_err_pid*
 /notifications/gradle
 /notifications/gradlew
 /notifications/gradlew.bat
+notifications-model/build/
 /notifications-integration-test/build/
 /d3testreport/gradle
 /d3testreport/gradlew

--- a/notifications-integration-test/build.gradle
+++ b/notifications-integration-test/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     implementation "io.ktor:ktor-server-netty:$ktor_version"
 
     implementation 'com.github.hyperledger.iroha-java:client:6.1.0'
-
+    implementation project(":notifications-model")
     // unit tests
     testImplementation('org.junit.jupiter:junit-jupiter-api:5.2.0')
     testRuntime('org.junit.jupiter:junit-jupiter-engine:5.2.0')

--- a/notifications-model/build.gradle
+++ b/notifications-model/build.gradle
@@ -1,0 +1,5 @@
+
+dependencies{
+    implementation group: 'com.google.code.gson', name: 'gson', version: '2.8.6'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+}

--- a/notifications-model/settings.gradle
+++ b/notifications-model/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'notifications-model'

--- a/notifications-model/src/main/kotlin/com/d3/notifications/event/BasicEvents.kt
+++ b/notifications-model/src/main/kotlin/com/d3/notifications/event/BasicEvents.kt
@@ -5,11 +5,11 @@
 
 package com.d3.notifications.event
 
-import com.d3.commons.util.GsonInstance
+import com.google.gson.Gson
 import java.math.BigDecimal
 import java.math.BigInteger
 
-private val gson = GsonInstance.get()
+private val gson = Gson()
 
 /**
  * Basic event class

--- a/notifications-model/src/main/kotlin/com/d3/notifications/event/SoraEvents.kt
+++ b/notifications-model/src/main/kotlin/com/d3/notifications/event/SoraEvents.kt
@@ -5,7 +5,7 @@
 
 package com.d3.notifications.event
 
-import com.d3.commons.util.GsonInstance
+import com.google.gson.Gson
 import java.math.BigDecimal
 import java.math.BigInteger
 
@@ -13,7 +13,7 @@ import java.math.BigInteger
  * The file contains data transfer objects for Sora notification REST service
  */
 
-private val gson = GsonInstance.get()
+private val gson = Gson()
 
 /**
  * Sora event

--- a/notifications/build.gradle
+++ b/notifications/build.gradle
@@ -45,6 +45,8 @@ dependencies {
 
     implementation project(":notary-commons")
 
+    implementation project(":notifications-model")
+
     // https://mvnrepository.com/artifact/nl.martijndwars/web-push
     implementation group: 'nl.martijndwars', name: 'web-push', version: '5.0.1'
 

--- a/notifications/src/main/kotlin/com/d3/notifications/service/EmailNotificationService.kt
+++ b/notifications/src/main/kotlin/com/d3/notifications/service/EmailNotificationService.kt
@@ -40,7 +40,7 @@ class EmailNotificationService(
     override fun notifySendToClient(transferNotifyEvent: Client2ClientSendTransferEvent): Result<Unit, Exception> {
         val toMessage = "to ${transferNotifyEvent.to} "
         val feeMessage = if (transferNotifyEvent.fee != null) {
-            "Fee is ${transferNotifyEvent.fee.amount} ${transferNotifyEvent.fee.assetName}"
+            "Fee is ${transferNotifyEvent.fee!!.amount} ${transferNotifyEvent.fee!!.assetName}"
         } else {
             ""
         }
@@ -66,7 +66,7 @@ class EmailNotificationService(
         val feeMessage = if (transferNotifyEvent.fee == null) {
             ""
         } else {
-            "Fee ${transferNotifyEvent.fee.amount} ${transferNotifyEvent.fee.assetName} is rolled back as well."
+            "Fee ${transferNotifyEvent.fee!!.amount} ${transferNotifyEvent.fee!!.assetName} is rolled back as well."
         }
         val message =
             "Dear client, unfortunately, we failed to withdraw ${transferNotifyEvent.amount} ${transferNotifyEvent.assetName} from your account ${transferNotifyEvent.accountIdToNotify}. " +
@@ -90,7 +90,7 @@ class EmailNotificationService(
     override fun notifyWithdrawal(transferNotifyEvent: WithdrawalTransferEvent): Result<Unit, Exception> {
         val toMessage = "to ${transferNotifyEvent.to} "
         val feeMessage = if (transferNotifyEvent.fee != null) {
-            "Fee is ${transferNotifyEvent.fee.amount} ${transferNotifyEvent.fee.assetName}"
+            "Fee is ${transferNotifyEvent.fee!!.amount} ${transferNotifyEvent.fee!!.assetName}"
         } else {
             ""
         }

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,6 +6,9 @@ project(':notifications-integration-test').projectDir = 'notifications-integrati
 include 'notifications'
 project(':notifications').projectDir = 'notifications' as File
 
+include 'notifications-model'
+project(':notifications-model').projectDir = 'notifications-model' as File
+
 include 'exchanger'
 project(':exchanger').projectDir = 'exchanger' as File
 


### PR DESCRIPTION
### Description of the Change
We need to store notification events in a separate project because we will refer to these objects in the future.